### PR TITLE
Hide implementation of Generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,26 @@ mod world;
 pub struct Generation(i32);
 
 impl Generation {
-    /// Returns `true` if entities of this generation are alive
+    /// Returns `true` if entities of this `Generation` are alive
     pub fn is_alive(&self) -> bool {
         self.0 > 0
     }
 
-    /// Returns `true` if entities of this generation are dead
-    pub fn is_dead(&self) -> bool {
-        !self.is_alive()
+    /// Kills this `Generation`
+    fn die(&mut self) {
+        debug_assert!(self.is_alive());
+        self.0 = -self.0;
+    }
+
+    /// Revive and increment a dead `Generation`
+    fn raised(self) -> Generation {
+        debug_assert!(!self.is_alive());
+        Generation(1 - self.0)
+    }
+
+    /// Returns `true` if this is a first generation, i.e. has value `1`
+    fn is_first(&self) -> bool {
+        self.0 == 1
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,24 @@ pub use world::{Component, World, FetchArg,
 mod storage;
 mod world;
 
-
 /// Index generation. When a new entity is placed at the old index,
 /// it bumps the generation by 1. This allows to avoid using components
 /// from the entities that were deleted.
-/// G<=0 - the entity of generation G is dead
-/// G >0 - the entity of generation G is alive
-pub type Generation = i32;
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Generation(i32);
+
+impl Generation {
+    /// Returns `true` if entities of this generation are alive
+    pub fn is_alive(&self) -> bool {
+        self.0 > 0
+    }
+
+    /// Returns `true` if entities of this generation are dead
+    pub fn is_dead(&self) -> bool {
+        !self.is_alive()
+    }
+}
+
 /// Index type is arbitrary. It doesn't show up in any interfaces.
 /// Keeping it 32bit allows for a single 64bit word per entity.
 pub type Index = u32;
@@ -40,7 +51,7 @@ pub struct Entity(Index, Generation);
 impl Entity {
     #[cfg(test)]
     /// Create a new entity (externally from ECS)
-    pub fn new(index: u32, gen: i32) -> Entity {
+    pub fn new(index: Index, gen: Generation) -> Entity {
         Entity(index, gen)
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -105,70 +105,70 @@ impl<T> Storage<T> for HashMapStorage<T> {
 
 #[cfg(test)]
 mod test {
-    use Entity;
+    use {Entity, Generation};
     use super::*;
 
     fn test_add<S>() where S: Storage<u32> {
         let mut s = S::new();
         for i in 0..1_000 {
-            s.insert(Entity::new(i, 1), i + 2718);
+            s.insert(Entity::new(i, Generation(1)), i + 2718);
         }
 
         for i in 0..1_000 {
-            assert_eq!(*s.get(Entity::new(i, 1)).unwrap(), i + 2718);
+            assert_eq!(*s.get(Entity::new(i, Generation(1))).unwrap(), i + 2718);
         }
     }
 
     fn test_sub<S>() where S: Storage<u32> {
         let mut s = S::new();
         for i in 0..1_000 {
-            s.insert(Entity::new(i, 1), i + 2718);
+            s.insert(Entity::new(i, Generation(1)), i + 2718);
         }
 
         for i in 0..1_000 {
-            assert_eq!(s.remove(Entity::new(i, 1)).unwrap(), i + 2718);
-            assert!(s.remove(Entity::new(i, 1)).is_none());
+            assert_eq!(s.remove(Entity::new(i, Generation(1))).unwrap(), i + 2718);
+            assert!(s.remove(Entity::new(i, Generation(1))).is_none());
         }
     }
 
     fn test_get_mut<S>() where S: Storage<u32> {
         let mut s = S::new();
         for i in 0..1_000 {
-            s.insert(Entity::new(i, 1), i + 2718);
+            s.insert(Entity::new(i, Generation(1)), i + 2718);
         }
 
         for i in 0..1_000 {
-            *s.get_mut(Entity::new(i, 1)).unwrap() -= 718;
+            *s.get_mut(Entity::new(i, Generation(1))).unwrap() -= 718;
         }
 
         for i in 0..1_000 {
-            assert_eq!(*s.get(Entity::new(i, 1)).unwrap(), i + 2000);
+            assert_eq!(*s.get(Entity::new(i, Generation(1))).unwrap(), i + 2000);
         }
     }
 
     fn test_add_gen<S>() where S: Storage<u32> {
         let mut s = S::new();
         for i in 0..1_000 {
-            s.insert(Entity::new(i, 1), i + 2718);
-            s.insert(Entity::new(i, 2), i + 31415);
+            s.insert(Entity::new(i, Generation(1)), i + 2718);
+            s.insert(Entity::new(i, Generation(2)), i + 31415);
         }
 
         for i in 0..1_000 {
             // this is removed since vec and hashmap disagree
             // on how this behavior should work...
             //assert!(s.get(Entity::new(i, 1)).is_none());
-            assert_eq!(*s.get(Entity::new(i, 2)).unwrap(), i + 31415);
+            assert_eq!(*s.get(Entity::new(i, Generation(2))).unwrap(), i + 31415);
         }
     }
 
     fn test_sub_gen<S>() where S: Storage<u32> {
         let mut s = S::new();
         for i in 0..1_000 {
-            s.insert(Entity::new(i, 2), i + 2718);
+            s.insert(Entity::new(i, Generation(2)), i + 2718);
         }
 
         for i in 0..1_000 {
-            assert!(s.remove(Entity::new(i, 1)).is_none());
+            assert!(s.remove(Entity::new(i, Generation(1))).is_none());
         }
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -221,7 +221,6 @@ impl World {
         }
         let mut gens = self.generations.write().unwrap();
         let mut gen = &mut gens[entity.get_id() as usize];
-        assert!(gen.is_alive());
         gen.die();
         let mut app = self.appendix.write().unwrap();
         if entity.get_id() < app.next.get_id() {

--- a/src/world.rs
+++ b/src/world.rs
@@ -59,15 +59,17 @@ struct Appendix {
 }
 
 fn find_next(gens: &[Generation], lowest_free_index: usize) -> Entity {
-    if let Some((id, gen)) = gens.iter().enumerate().skip(lowest_free_index).find(|&(_, g)| g.is_dead()) {
-        return Entity(id as Index, Generation(1 - gen.0));
+    if let Some((id, gen)) = gens.iter().enumerate().skip(lowest_free_index).find(|&(_, g)| !g.is_alive()) {
+        return Entity(id as Index, gen.raised());
     }
 
-    if lowest_free_index > gens.len() {
-        Entity(lowest_free_index as Index, Generation(1))
+    let new_index = if lowest_free_index > gens.len() {
+        lowest_free_index as Index
     } else {
-        Entity(gens.len() as Index, Generation(1))
-    }
+        gens.len() as Index
+    };
+
+    Entity(new_index, Generation(1))
 }
 
 /// Entity creation iterator. Will yield new empty entities infinitely.
@@ -82,7 +84,7 @@ impl<'a> Iterator for CreateEntityIter<'a> {
     fn next(&mut self) -> Option<Entity> {
         let ent = self.app.next;
         assert!(ent.get_gen().is_alive());
-        if ent.get_gen().0 == 1 {
+        if ent.get_gen().is_first() {
             assert!(self.gens.len() == ent.get_id());
             self.gens.push(ent.get_gen());
             self.app.next.0 += 1;
@@ -201,7 +203,7 @@ impl World {
         let mut app = self.appendix.write().unwrap();
         let ent = app.next;
         assert!(ent.get_gen().is_alive());
-        if ent.get_gen().0 == 1 {
+        if ent.get_gen().is_first() {
             let mut gens = self.generations.write().unwrap();
             assert!(gens.len() == ent.get_id());
             gens.push(ent.get_gen());
@@ -220,11 +222,11 @@ impl World {
         let mut gens = self.generations.write().unwrap();
         let mut gen = &mut gens[entity.get_id() as usize];
         assert!(gen.is_alive());
+        gen.die();
         let mut app = self.appendix.write().unwrap();
         if entity.get_id() < app.next.get_id() {
-            app.next = Entity(entity.0, Generation(gen.0 + 1));
+            app.next = Entity(entity.0, gen.raised());
         }
-        gen.0 *= -1;
     }
     /// Create a new entity dynamically.
     pub fn create_later(&self) -> Entity {
@@ -255,17 +257,18 @@ impl World {
                 while gens.len() <= ent.get_id() {
                     gens.push(Generation(0));
                 }
-                assert_eq!(ent.get_gen().0, 1 - gens[ent.get_id()].0);
+                assert_eq!(ent.get_gen(), gens[ent.get_id()].raised());
                 gens[ent.get_id()] = ent.get_gen();
             }
             let mut next = app.next;
             for ent in app.sub_queue.drain(..) {
                 assert_eq!(ent.get_gen(), gens[ent.get_id()]);
+                let gen = &mut gens[ent.get_id()];
+                gen.die();
                 temp_list.push(ent);
                 if ent.get_id() < next.get_id() {
-                    next = Entity(ent.0, Generation(ent.get_gen().0 + 1));
+                    next = Entity(ent.0, gen.raised());
                 }
-                gens[ent.get_id()].0 *= -1;
             }
             app.next = next;
         }


### PR DESCRIPTION
Instead, expose `is_alive()` and `is_dead()` methods which have a clear
name, and refactor existing code to use these.