### PR TITLE
Cleanup documenation at many places.

### DIFF
--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -234,8 +234,9 @@ impl BitSetLike for BitSet {
     #[inline] fn layer0(&self, i: usize) -> u32 { self.layer0[i] }
 }
 
-/// `BitSet` and takes two BitSetLike items and merges the masks
-/// returning a new virtual set.
+/// `BitSetAnd` takes two `BitSetLike` items, and merges the masks
+/// returning a new virtual set, which represents an intersection of the
+/// two original sets.
 pub struct BitSetAnd<A: BitSetLike, B: BitSetLike>(pub A, pub B);
 
 impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetAnd<A, B> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,9 +8,9 @@ use bitset::BitSet;
 
 
 /// Base trait for a component storage that is used as a trait object.
-/// Doesn't depent on the actual component type.
+/// Doesn't depend on the actual component type.
 pub trait StorageBase {
-    /// Delete a particular entity from the storage.
+    /// Deletes a particular `Entity` from the storage.
     fn del(&mut self, Entity);
 }
 
@@ -19,34 +19,34 @@ pub trait Storage<T>: StorageBase + Sized {
     /// Used during iterator
     type UnprotectedStorage: UnprotectedStorage<T>;
 
-    /// Create a new storage. This is called when you register a new
+    /// Creates a new `Storage<T>`. This is called when you register a new
     /// component type within the world.
     fn new() -> Self;
-    /// Insert a new data for a given entity.
+    /// Inserts new data for a given `Entity`.
     fn insert(&mut self, Entity, T);
-    /// Try reading the data associated with an entity.
+    /// Tries to read the data associated with an `Entity`.
     fn get(&self, Entity) -> Option<&T>;
-    /// Try mutating the data associated with an entity.
+    /// Tries to mutate the data associated with an `Entity`.
     fn get_mut(&mut self, Entity) -> Option<&mut T>;
-    /// Remove the data associated with an entity.
+    /// Removes the data associated with an `Entity`.
     fn remove(&mut self, Entity) -> Option<T>;
-    /// splits the bitset from the storage for use
-    /// by the join iterator.
+    /// Splits the `BitSet` from the storage for use
+    /// by the `Join` iterator.
     fn open(&self) -> (&BitSet, &Self::UnprotectedStorage);
-    /// splits the bitset from the storage for use
-    /// by the join iterator.
+    /// Splits the `BitSet` mutably from the storage for use
+    /// by the `Join` iterator.
     fn open_mut(&mut self) -> (&BitSet, &mut Self::UnprotectedStorage);
 }
 
 /// Used by the framework to quickly join componets
 pub trait UnprotectedStorage<T> {
-    /// Try reading the data associated with an entity.
-    /// this is unsafe because the external set used
-    /// to protect this storage is absent
+    /// Tries reading the data associated with an `Entity`.
+    /// This is unsafe because the external set used
+    /// to protect this storage is absent.
     unsafe fn get(&self, id: Index) -> &T;
-    /// Try mutating the data associated with an entity.
-    /// this is unsafe because the external set used
-    /// to protect this storage is absent
+    /// Tries mutating the data associated with an `Entity`.
+    /// This is unsafe because the external set used
+    /// to protect this storage is absent.
     unsafe fn get_mut(&mut self, id: Index) -> &mut T;
 }
 
@@ -136,8 +136,8 @@ pub struct GenerationData<T> {
 }
 
 
-/// Vec-based storage, actually wraps data into options and stores the generations
-/// of the data in order to match with given entities. Supposed to have maximum
+/// Vec-based storage, stores the generations of the data in
+/// order to match with given entities. Supposed to have maximum
 /// performance for the components mostly present in entities.
 pub struct VecStorage<T> {
     set: BitSet,

--- a/src/world.rs
+++ b/src/world.rs
@@ -127,8 +127,8 @@ impl<S: StorageBase + Any + Send + Sync> StorageLock for RwLock<S> {
 }
 
 
-/// The world struct contains all the data, which is entities and their components.
-/// The methods are supposed to be valid for any context they are available in.
+/// The `World` struct contains all the data, which is entities and their components.
+/// All methods are supposed to be valid for any context they are available in.
 pub struct World {
     generations: RwLock<Vec<Generation>>,
     components: HashMap<TypeId, Box<StorageLock>>,
@@ -136,7 +136,7 @@ pub struct World {
 }
 
 impl World {
-    /// Create a new empty world.
+    /// Creates a new empty `World`.
     pub fn new() -> World {
         World {
             generations: RwLock::new(Vec::new()),
@@ -148,12 +148,12 @@ impl World {
             }),
         }
     }
-    /// Register a new component type.
+    /// Registers a new component type.
     pub fn register<T: Component>(&mut self) {
         let any = RwLock::new(T::Storage::new());
         self.components.insert(TypeId::of::<T>(), Box::new(any));
     }
-    /// Unregister a component type.
+    /// Unregisters a component type.
     pub fn unregister<T: Component>(&mut self) -> Option<T::Storage> {
         self.components.remove(&TypeId::of::<T>()).map(|boxed|
             match boxed.downcast::<RwLock<T::Storage>>() {
@@ -167,22 +167,22 @@ impl World {
             .expect("Tried to perform an operation on type that was not registered");
         boxed.downcast_ref().unwrap()
     }
-    /// Lock a component's storage for reading.
+    /// Locks a component's storage for reading.
     pub fn read<T: Component>(&self) -> RwLockReadGuard<T::Storage> {
         self.lock::<T>().read().unwrap()
     }
-    /// Lock a component's storage for writing.
+    /// Locks a component's storage for writing.
     pub fn write<T: Component>(&self) -> RwLockWriteGuard<T::Storage> {
         self.lock::<T>().write().unwrap()
     }
-    /// Return the entity iterator.
+    /// Returns the entity iterator.
     pub fn entities(&self) -> EntityIter {
         EntityIter {
             guard: self.generations.read().unwrap(),
             index: 0,
         }
     }
-    /// Return the dynamic entity iterator. It goes through entities that were
+    /// Returns the dynamic entity iterator. It iterates over entities that were
     /// dynamically created by systems but not yet merged.
     pub fn dynamic_entities(&self) -> DynamicEntityIter {
         DynamicEntityIter {
@@ -190,7 +190,7 @@ impl World {
             index: 0,
         }
     }
-    /// Return the entity creation iterator. Can be used to create many
+    /// Returns the entity creation iterator. Can be used to create many
     /// empty entities at once without paying the locking overhead.
     pub fn create_iter(&self) -> CreateEntityIter {
         CreateEntityIter {
@@ -198,7 +198,7 @@ impl World {
             app: self.appendix.write().unwrap(),
         }
     }
-    /// Create a new entity instantly, with locking the generations data.
+    /// Creates a new entity instantly, locking the generations data.
     pub fn create_now(&self) -> EntityBuilder {
         let mut app = self.appendix.write().unwrap();
         let ent = app.next;
@@ -215,7 +215,7 @@ impl World {
         }
         EntityBuilder(ent, self)
     }
-    /// Delete a new entity instantly, with locking the generations data.
+    /// Deletes a new entity instantly, locking the generations data.
     pub fn delete_now(&self, entity: Entity) {
         for comp in self.components.values() {
             comp.del_slice(&[entity]);
@@ -228,7 +228,7 @@ impl World {
             app.next = Entity(entity.0, gen.raised());
         }
     }
-    /// Create a new entity dynamically.
+    /// Creates a new entity dynamically.
     pub fn create_later(&self) -> Entity {
         let mut app = self.appendix.write().unwrap();
         let ent = app.next;
@@ -236,18 +236,18 @@ impl World {
         app.next = find_next(&*self.generations.read().unwrap(), ent.get_id() + 1);
         ent
     }
-    /// Delete an entity dynamically.
+    /// Deletes an entity dynamically.
     pub fn delete_later(&self, entity: Entity) {
         let mut app = self.appendix.write().unwrap();
         app.sub_queue.push(entity);
     }
-    /// Checks whether the given `Entity` is alive.
+    /// Returns `true` if the given `Entity` is alive.
     pub fn is_alive(&self, entity: Entity) -> bool {
         debug_assert!(entity.get_gen().is_alive());
         let gens = self.generations.read().unwrap();
         entity.get_gen() == gens[entity.get_id()]
     }
-    /// Merge in the appendix, recording all the dynamically created
+    /// Merges in the appendix, recording all the dynamically created
     /// and deleted entities into the persistent generations vector.
     /// Also removes all the abandoned components.
     pub fn merge(&self) {
@@ -289,20 +289,20 @@ impl World {
 pub struct FetchArg<'a>(&'a World);
 
 impl<'a> FetchArg<'a> {
-    /// Construct the new arg, not supposed to be used.
+    /// Constructs a new `FetchArg`, not supposed to be used.
     #[doc(hidden)]
     pub fn new(w: &'a World) -> FetchArg<'a> {
         FetchArg(w)
     }
-    /// Lock a component for reading.
+    /// Locks a component for reading.
     pub fn read<T: Component>(&self) -> RwLockReadGuard<'a, T::Storage> {
         self.0.read::<T>()
     }
-    /// Lock a component for writing.
+    /// Locks a component for writing.
     pub fn write<T: Component>(&self) -> RwLockWriteGuard<'a, T::Storage> {
         self.0.write::<T>()
     }
-    /// Return the entity iterator.
+    /// Returns the entity iterator.
     pub fn entities(self) -> EntityIter<'a> {
         self.0.entities()
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -40,12 +40,12 @@ impl<'a> Iterator for EntityIter<'a> {
 pub struct EntityBuilder<'a>(Entity, &'a World);
 
 impl<'a> EntityBuilder<'a> {
-    /// Add a component value to the new entity.
+    /// Adds a `Component` value to the new `Entity`.
     pub fn with<T: Component>(self, value: T) -> EntityBuilder<'a> {
         self.1.write::<T>().insert(self.0, value);
         self
     }
-    /// Finish entity construction.
+    /// Finishes entity construction.
     pub fn build(self) -> Entity {
         self.0
     }
@@ -285,7 +285,7 @@ impl World {
 }
 
 /// System fetch-time argument. The fetch is executed at the start of the run.
-/// It contains a subset of World methods that make sense during initialization.
+/// It contains a subset of `World` methods that make sense during initialization.
 pub struct FetchArg<'a>(&'a World);
 
 impl<'a> FetchArg<'a> {
@@ -294,11 +294,11 @@ impl<'a> FetchArg<'a> {
     pub fn new(w: &'a World) -> FetchArg<'a> {
         FetchArg(w)
     }
-    /// Locks a component for reading.
+    /// Locks a `Component` for reading.
     pub fn read<T: Component>(&self) -> RwLockReadGuard<'a, T::Storage> {
         self.0.read::<T>()
     }
-    /// Locks a component for writing.
+    /// Locks a `Component` for writing.
     pub fn write<T: Component>(&self) -> RwLockWriteGuard<'a, T::Storage> {
         self.0.write::<T>()
     }


### PR DESCRIPTION
Also turns all comments of the form `Return value x` into the form
`Returns value x`, which is in line with official rust docs.