### PR TITLE
Add a `Join` trait

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -68,7 +68,7 @@ fn main() {
         // Instead of using the `entities` array you can
         // use the `Join` trait that is an optimized way of
         // doing the `get/get_mut` across entities.
-        for (a, b) in (&mut *sa, &*sb).join() {
+        for (a, b) in (&mut sa, &sb).join() {
             a.0 += if b.0 {1} else {0};
         }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Instead of using macros you can use run() to build a system precisely
     planner.run(|arg| {
-        use specs::Storage;
+        use specs::{Storage, Join};
         // fetch() borrows a world, so a system could lock neccessary storages
         // Can be called only once
         let (mut sa, sb, entities) = arg.fetch(|w| {
@@ -61,11 +61,18 @@ fn main() {
         for ent in entities {
             // Will only run for entities with both components present
             if let (Some(a), Some(b)) = (sa.get_mut(ent), sb.get(ent)) {
-                a.0 = if b.0 {2} else {0};
+                a.0 = if b.0 {1} else {0};
             }
         }
 
-        // Dynamically creating and deleting entites
+        // Instead of using the `entities` array you can
+        // use the `Join` trait that is an optimized way of
+        // doing the `get/get_mut` across entities.
+        for (a, b) in (&mut *sa, &*sb).join() {
+            a.0 += if b.0 {1} else {0};
+        }
+
+        // Dynamically creating and deleting entities
         let e0 = arg.create();
         sa.insert(e0, CompInt(-4));
         let e1 = arg.create();

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -208,7 +208,7 @@ pub trait BitSetLike {
     fn layer0(&self, i: usize) -> u32;
 
     /// Create an iterator that will scan over the keyspace
-    fn iter<'a>(&'a self) -> Iter<'a, Self>
+    fn iter(self) -> Iter<Self>
         where Self: Sized
     {
         Iter{
@@ -246,14 +246,14 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetAnd<A, B> {
     #[inline] fn layer0(&self, i: usize) -> u32 { self.0.layer0(i) & self.1.layer0(i) }
 }
 
-pub struct Iter<'a, T:'a> {
-    set: &'a T,
+pub struct Iter<T> {
+    set: T,
     masks: [u32; 4],
     prefix: [u32; 3]
 }
 
-impl<'a, T> Iterator for Iter<'a, T>
-    where T: BitSetLike+'a
+impl<T> Iterator for Iter<T>
+    where T: BitSetLike
 {
     type Item = Index;
 
@@ -367,8 +367,8 @@ mod set_test {
             }
         }
 
-        assert_eq!(odd.iter().count(), 50_000);
-        assert_eq!(even.iter().count(), 50_000);
+        assert_eq!((&odd).iter().count(), 50_000);
+        assert_eq!((&even).iter().count(), 50_000);
         assert_eq!(BitSetAnd(&odd, &even).iter().count(), 0);
     }
 }

--- a/src/join.rs
+++ b/src/join.rs
@@ -86,6 +86,30 @@ impl<'a, T> Open for &'a mut T
     }
 }
 
+impl<'a, T> Open for &'a std::sync::RwLockReadGuard<'a, T>
+    where T: Storage
+{
+    type Value = GetRef<'a, T::UnprotectedStorage>;
+    type Mask = &'a BitSet;
+    fn open(self) -> (Self::Mask, Self::Value) {
+        let (l, r) = (**self).open();
+        (l, GetRef(r))
+    }
+}
+
+impl<'b, 'a:'b, T> Open for &'b mut std::sync::RwLockWriteGuard<'a, T>
+    where T: Storage
+{
+    type Value = GetMut<'b, T::UnprotectedStorage>;
+    type Mask = &'b BitSet;
+    fn open(self) -> (Self::Mask, Self::Value) {
+        let (l, r) = (**self).open_mut();
+        (l, GetMut(r))
+    }
+}
+
+
+
 /// Get like `Open` provides the same feature of providing
 /// mutable vs immutable preserving around the UnprotectedStorage
 /// trait

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,52 +1,219 @@
+use std;
 use tuple_utils::Split;
-use {BitSetAnd, BitSetLike};
+use bitset;
+use {Index};
+use {BitSet, BitSetAnd, BitSetLike, Storage, UnprotectedStorage};
 
-/// Join is a helper method to & bitsets togather resulting in a tree
-pub trait Join {
-    type Value;
-    fn join(self) -> Self::Value;
+/// BitAnd is a helper method to & bitsets togather resulting in a tree
+pub trait BitAnd {
+    type Value: BitSetLike;
+    fn and(self) -> Self::Value;
 }
 
 /// This needs to be special cased
-impl<A> Join for (A,)
+impl<A> BitAnd for (A,)
     where A: BitSetLike
 {
     type Value = A;
-    fn join(self) -> Self::Value {
+    fn and(self) -> Self::Value {
         self.0
     }
 }
 
-macro_rules! merge_impl {
+macro_rules! bitset_and {
     // use variables to indicate the arity of the tuple
     ($($from:ident),*) => {
-      impl<$($from),*> Join for ($($from),*)
-          where $($from: BitSetLike),*
-      {
-          type Value = BitSetAnd<
-            <<Self as Split>::Left as Join>::Value,
-            <<Self as Split>::Right as Join>::Value
-          >;
-          fn join(self) -> Self::Value {
+        impl<$($from),*> BitAnd for ($($from),*)
+            where $($from: BitSetLike),*
+        {
+            type Value = BitSetAnd<
+                <<Self as Split>::Left as BitAnd>::Value,
+                <<Self as Split>::Right as BitAnd>::Value
+            >;
+            fn and(self) -> Self::Value {
               let (l, r) = self.split();
-              BitSetAnd(l.join(), r.join())
-          }
-      }
+              BitSetAnd(l.and(), r.and())
+            }
+        }
     }
 }
 
-merge_impl!{A, B}
-merge_impl!{A, B, C}
-merge_impl!{A, B, C, D}
-merge_impl!{A, B, C, D, E}
-merge_impl!{A, B, C, D, E, F}
-merge_impl!{A, B, C, D, E, F, G}
-merge_impl!{A, B, C, D, E, F, G, H}
-merge_impl!{A, B, C, D, E, F, G, H, I}
-merge_impl!{A, B, C, D, E, F, G, H, I, J}
-merge_impl!{A, B, C, D, E, F, G, H, I, J, K}
-merge_impl!{A, B, C, D, E, F, G, H, I, J, K, L}
-merge_impl!{A, B, C, D, E, F, G, H, I, J, K, L, M}
-merge_impl!{A, B, C, D, E, F, G, H, I, J, K, L, M, N}
-merge_impl!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O}
-merge_impl!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}
+bitset_and!{A, B}
+bitset_and!{A, B, C}
+bitset_and!{A, B, C, D}
+bitset_and!{A, B, C, D, E}
+bitset_and!{A, B, C, D, E, F}
+bitset_and!{A, B, C, D, E, F, G}
+bitset_and!{A, B, C, D, E, F, G, H}
+bitset_and!{A, B, C, D, E, F, G, H, I}
+bitset_and!{A, B, C, D, E, F, G, H, I, J}
+bitset_and!{A, B, C, D, E, F, G, H, I, J, K}
+bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L}
+bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M}
+bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M, N}
+bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O}
+bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}
+
+pub trait Open {
+  type Value;
+  type Mask: BitSetLike;
+  fn open(self) -> (Self::Mask, Self::Value);
+}
+
+impl<'a, T> Open for &'a T
+  where T: Storage
+{
+  type Value = GetRef<'a, <T as Storage>::UnprotectedStorage>;
+  type Mask = &'a BitSet;
+  fn open(self) -> (Self::Mask, Self::Value) {
+    let (l,r) = self.open();
+    (l, GetRef(r))
+  }
+}
+
+impl<'a, T> Open for &'a mut T
+  where T: Storage,
+{
+  type Value = GetMut<'a, <T as Storage>::UnprotectedStorage>;
+  type Mask = &'a BitSet;
+  fn open(self) -> (Self::Mask, Self::Value) {
+    let (l,r) = self.open_mut();
+    (l, GetMut(r))
+  }
+}
+
+pub trait Get {
+    type Value;
+    unsafe fn get(&self, idx: Index) -> Self::Value;
+}
+
+pub struct GetRef<'a, T:'a>(&'a T);
+impl<'a, T> Get for GetRef<'a, T>
+    where T: UnprotectedStorage
+{
+    type Value = &'a <T as UnprotectedStorage>::Component;
+    unsafe fn get(&self, idx: Index) -> Self::Value {
+        self.0.get(idx)
+    }
+}
+
+pub struct GetMut<'a, T:'a>(&'a mut T);
+impl<'a, T> Get for GetMut<'a, T>
+    where T: UnprotectedStorage
+{
+    type Value = &'a mut <T as UnprotectedStorage>::Component;
+    #[allow(mutable_transmutes)]
+    unsafe fn get(&self, idx: Index) -> Self::Value {
+        let x: &mut Self = std::mem::transmute(self);
+        x.0.get_mut(idx)
+    }
+}
+
+pub struct Joined<K, V> {
+    keys: bitset::Iter<K>,
+    values: V
+}
+
+impl<K, V> Joined<K, V>
+  where K: BitSetLike
+{
+  fn new(k: K, v: V) -> Joined<K, V> {
+    Joined{
+      keys: k.iter(),
+      values: v
+    }
+  }
+}
+
+impl<K, V> std::iter::Iterator for Joined<K, V>
+    where K: BitSetLike,
+          V: Get
+{
+    type Item = <V as Get>::Value;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(idx) = self.keys.next() {
+            unsafe {
+                Some(self.values.get(idx))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// Join one or more `Storage` components together
+/// this will return an iterator that will return
+/// the components of an entity
+pub trait Join {
+    /// The Mask selects which elements are found in the 
+    /// Values collection
+    type Mask;
+    /// The Values is a tuple of `UnprotectedStorage`
+    type Values;
+    /// Join the `Storages` togather
+    fn join(self) -> Joined<Self::Mask, Self::Values>;
+}
+
+macro_rules! define_open {
+    // use variables to indicate the arity of the tuple
+    ($($from:ident),*) => {
+        impl<'a, $($from,)*> Open for ($($from),*,)
+            where $($from: Open),*,
+                  ($(<$from as Open>::Mask,)*): BitAnd,
+        {
+            type Value = ($(<$from as Open>::Value),*,);
+            type Mask = <($(<$from as Open>::Mask,)*) as BitAnd>::Value;
+            #[allow(non_snake_case)]
+            fn open(self) -> (Self::Mask, Self::Value) {
+                let ($($from,)*) = self;
+                let ($($from,)*) = ($($from.open(),)*);
+                (
+                    ($($from.0),*,).and(),
+                    ($($from.1),*,)
+                )
+            }
+        }
+
+        impl<'a, $($from,)*> Get for ($($from),*,)
+            where $($from: Get),*,
+        {
+            type Value = ($(<$from as Get>::Value),*,);
+            #[allow(non_snake_case)]
+            unsafe fn get(&self, idx: Index) -> Self::Value {
+                let &($(ref $from,)*) = self;
+                ($($from.get(idx)),*,)
+            }
+        }
+
+        impl<'a, $($from,)*> Join for ($($from),*,)
+            where $($from: Open),*,
+                  ($(<$from as Open>::Mask),*,): BitAnd,
+        {
+            type Mask = <($(<$from as Open>::Mask),*,) as BitAnd>::Value;
+            type Values = ($(<$from as Open>::Value),*,);
+
+            fn join(self) -> Joined<Self::Mask, Self::Values> {
+                let (mask, value) = self.open();
+                Joined::new(mask, value)
+            }
+        }
+
+    }
+}
+
+define_open!{A}
+define_open!{A, B}
+define_open!{A, B, C}
+define_open!{A, B, C, D}
+define_open!{A, B, C, D, E}
+define_open!{A, B, C, D, E, F}
+define_open!{A, B, C, D, E, F, G}
+define_open!{A, B, C, D, E, F, G, H}
+define_open!{A, B, C, D, E, F, G, H, I}
+define_open!{A, B, C, D, E, F, G, H, I, J}
+define_open!{A, B, C, D, E, F, G, H, I, J, K}
+define_open!{A, B, C, D, E, F, G, H, I, J, K, L}
+define_open!{A, B, C, D, E, F, G, H, I, J, K, L, M}
+define_open!{A, B, C, D, E, F, G, H, I, J, K, L, M, N}
+define_open!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O}
+define_open!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ macro_rules! impl_run {
                      $(w.read::<$read>(),)*)
                 );
 
-                for ($($write,)* $($read,)*) in ($(&mut *$write,)* $(&*$read,)*).join() {
+                for ($($write,)* $($read,)*) in ($(&mut $write,)* $(&$read,)*).join() {
                     fun( $($write,)* $($read,)* );
                 }
             });

--- a/src/world.rs
+++ b/src/world.rs
@@ -8,7 +8,7 @@ use {Index, Generation, Entity, StorageBase, Storage};
 /// Abstract component type. Doesn't have to be Copy or even Clone.
 pub trait Component: Any + Sized {
     /// Associated storage type for this component.
-    type Storage: Storage<Self> + Any + Send + Sync;
+    type Storage: Storage<Component=Self> + Any + Send + Sync;
 }
 
 


### PR DESCRIPTION
This is a follow-up to my changes that added the bitset masks. This gives a way for api users to do the bitset join in a much more friendly way then we were doing before.

Take a look at the updated example to see how it works.
