### PR TITLE
Major Storage refactor

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -83,17 +83,16 @@ fn main() {
         println!("Entity {} {}", a.0, b.0);
     });
     planner.run_custom(|arg| {
-        use specs::{Storage, Join};
         let (mut sa, sb, entities) = arg.fetch(|w| {
             (w.write::<CompFloat>(), w.read::<CompInt>(), w.entities())
         });
 
         // Insert a component for each entity in sb
-        for (eid, sb) in (&entities, &sb).join() {
+        for (eid, sb) in (&entities, &sb).iter() {
             sa.insert(eid, CompFloat(sb.0 as f32));
         }
 
-        for (eid, sa, sb) in (&entities, &mut sa, &sb).join() {
+        for (eid, sa, sb) in (&entities, &mut sa, &sb).iter() {
             assert_eq!(sa.0 as u32, sb.0 as u32);
             println!("eid[{:?}] = {:?} {:?}", eid, sa, sb);
         }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 extern crate specs;
+use specs::Join;
 
 #[derive(Clone, Debug)]
 struct CompInt(i8);
@@ -66,7 +67,7 @@ fn main() {
         // Instead of using the `entities` array you can
         // use the `Join` trait that is an optimized way of
         // doing the `get/get_mut` across entities.
-        for (a, b) in specs::Join::from((&mut sa, &sb)) {
+        for (a, b) in (&mut sa, &sb).iter() {
             a.0 += if b.0 {2} else {0};
         }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -57,7 +57,6 @@ fn main() {
 
     // Instead of using macros you can use run_custom() to build a system precisely
     planner.run_custom(|arg| {
-        use specs::{Storage, Join};
         // fetch() borrows a world, so a system could lock neccessary storages
         // Can be called only once
         let (mut sa, sb) = arg.fetch(|w| {
@@ -67,7 +66,7 @@ fn main() {
         // Instead of using the `entities` array you can
         // use the `Join` trait that is an optimized way of
         // doing the `get/get_mut` across entities.
-        for (a, b) in (&mut sa, &sb).join() {
+        for (a, b) in specs::Join::from((&mut sa, &sb)) {
             a.0 += if b.0 {2} else {0};
         }
 

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -209,10 +209,10 @@ pub trait BitSetLike {
     fn layer0(&self, i: usize) -> usize;
 
     /// Create an iterator that will scan over the keyspace
-    fn iter(self) -> Iter<Self>
+    fn iter(self) -> BitIter<Self>
         where Self: Sized
     {
-        Iter{
+        BitIter {
             prefix: [0; 3],
             masks: [0, 0, 0, self.layer3()],
             set: self
@@ -260,13 +260,13 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetOr<A, B> {
 }
 
 
-pub struct Iter<T> {
+pub struct BitIter<T> {
     set: T,
     masks: [usize; 4],
     prefix: [u32; 3]
 }
 
-impl<T> Iterator for Iter<T>
+impl<T> Iterator for BitIter<T>
     where T: BitSetLike
 {
     type Item = Index;

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -155,7 +155,7 @@ impl BitSet {
 
     /// Returns `true` if `id` is in the set.
     #[inline]
-    pub fn contains(&self, id: u32) -> bool {
+    pub fn contains(&self, id: Index) -> bool {
         let p0 = id.offset(SHIFT1);
         p0 < self.layer0.len() && (self.layer0[p0] & id.mask(SHIFT0)) != 0
     }

--- a/src/join.rs
+++ b/src/join.rs
@@ -77,6 +77,7 @@ pub trait Join {
 
 
 /// `JoinIter` is an Iterator over a group of `Storages`.
+#[must_use]
 pub struct JoinIter<J: Join> {
     keys: BitIter<J::Mask>,
     values: J::Value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,16 +18,16 @@ use std::sync::{mpsc, Arc};
 use pulse::{Pulse, Signal, Signals};
 use threadpool::ThreadPool;
 
-pub use storage::{Storage, StorageBase, VecStorage, HashMapStorage, UnprotectedStorage};
+pub use storage::{Storage, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
     EntityBuilder, Entities, CreateEntities};
 pub use bitset::{BitSetAnd, BitSet, BitSetLike, AtomicBitSet};
-pub use join::Join;
+//pub use join::Join; //TEMP
 
 mod storage;
 mod world;
 mod bitset;
-mod join;
+//mod join; TEMP
 
 /// Index generation. When a new entity is placed at an old index,
 /// it bumps the `Generation` by 1. This allows to avoid using components
@@ -70,7 +70,7 @@ impl Entity {
 
     /// Returns the index of the `Entity`.
     #[inline]
-    pub fn get_id(&self) -> usize { self.0 as usize }
+    pub fn get_id(&self) -> Index { self.0 }
     /// Returns the `Generation` of the `Entity`.
     #[inline]
     pub fn get_gen(&self) -> Generation { self.1 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,13 @@ pub use storage::{Storage, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
     EntityBuilder, Entities, CreateEntities};
 pub use bitset::{BitSetAnd, BitSet, BitSetLike, AtomicBitSet};
-//pub use join::Join; //TEMP
+pub use join::Joined;
 
 mod storage;
 mod world;
 mod bitset;
-//mod join; TEMP
+mod join;
+
 
 /// Index generation. When a new entity is placed at an old index,
 /// it bumps the `Generation` by 1. This allows to avoid using components
@@ -249,7 +250,7 @@ macro_rules! impl_run {
                      $(w.read::<$read>(),)*)
                 );
 
-                for ($($write,)* $($read,)*) in ($(&mut $write,)* $(&$read,)*).join() {
+                for ($($write,)* $($read,)*) in Joined::from(($(&mut $write,)* $(&$read,)*)) {
                     fun( $($write,)* $($read,)* );
                 }
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use storage::{Storage, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
     EntityBuilder, Entities, CreateEntities};
 pub use bitset::{BitSetAnd, BitSet, BitSetLike, AtomicBitSet};
-pub use join::Join;
+pub use join::{Join, JoinIter};
 
 mod storage;
 mod world;
@@ -250,7 +250,7 @@ macro_rules! impl_run {
                      $(w.read::<$read>(),)*)
                 );
 
-                for ($($write,)* $($read,)*) in Join::from(($(&mut $write,)* $(&$read,)*)) {
+                for ($($write,)* $($read,)*) in JoinIter::new(($(&mut $write,)* $(&$read,)*)) {
                     fun( $($write,)* $($read,)* );
                 }
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl<C: 'static> Planner<C> {
             }
             self.wait_count -= 1;
         }
-        self.world.merge();
+        self.world.maintain();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use storage::{Storage, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
     EntityBuilder, Entities, CreateEntities};
 pub use bitset::{BitSetAnd, BitSet, BitSetLike, AtomicBitSet};
-pub use join::Joined;
+pub use join::Join;
 
 mod storage;
 mod world;
@@ -250,7 +250,7 @@ macro_rules! impl_run {
                      $(w.read::<$read>(),)*)
                 );
 
-                for ($($write,)* $($read,)*) in Joined::from(($(&mut $write,)* $(&$read,)*)) {
+                for ($($write,)* $($read,)*) in Join::from(($(&mut $write,)* $(&$read,)*)) {
                     fun( $($write,)* $($read,)* );
                 }
             });

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -136,7 +136,7 @@ impl<'a, T, D, G> Join for &'a Storage<T, D, G> where
     fn open(self) -> (Self::Mask, Self::Value) {
         (&self.data.mask, &self.data.inner)
     }
-    unsafe fn get(v: Self::Value, i: Index) -> &'a T {
+    unsafe fn get(v: &mut Self::Value, i: Index) -> &'a T {
         v.get(i)
     }
 }
@@ -152,8 +152,13 @@ impl<'a, T, D, G> Join for &'a mut Storage<T, D, G> where
     fn open(self) -> (Self::Mask, Self::Value) {
         self.data.open()
     }
-    unsafe fn get(v: Self::Value, i: Index) -> &'a mut T {
-        v.get_mut(i)
+    unsafe fn get(v: &mut Self::Value, i: Index) -> &'a mut T {
+        use std::mem;
+        // This is horribly unsafe. Unfortunately, Rust doesn't provide a way
+        // to abstract mutable/immutable state at the moment, so we have to hack
+        // our way through it.
+        let value: &'a mut Self::Value = mem::transmute(v);
+        value.get_mut(i)
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 use fnv::FnvHasher;
 
 use bitset::BitSet;
-use join::Open;
+use join::Join;
 use world::Component;
 use {Entity, Index, Generation};
 
@@ -125,7 +125,7 @@ impl<T, D, G> Storage<T, D, G> where
     }
 }
 
-impl<'a, T, D, G> Open for &'a Storage<T, D, G> where
+impl<'a, T, D, G> Join for &'a Storage<T, D, G> where
     T: Component,
     D: Deref<Target = MaskedStorage<T>>,
     G: Deref<Target = Vec<Generation>>,
@@ -141,7 +141,7 @@ impl<'a, T, D, G> Open for &'a Storage<T, D, G> where
     }
 }
 
-impl<'a, T, D, G> Open for &'a mut Storage<T, D, G> where
+impl<'a, T, D, G> Join for &'a mut Storage<T, D, G> where
     T: Component,
     D: DerefMut<Target = MaskedStorage<T>>,
     G: Deref<Target = Vec<Generation>>,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -263,9 +263,7 @@ mod map_test {
 
     #[test]
     fn insert() {
-        let mut ms = MaskedStorage::new();
-        let mut gen = Vec::new();
-        let mut c = Storage::new(&mut ms, &mut gen);
+        let mut c = Storage::new(Box::new(MaskedStorage::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             c.insert(ent(i), Comp(i));
@@ -278,9 +276,7 @@ mod map_test {
 
     #[test]
     fn insert_100k() {
-        let mut ms = MaskedStorage::new();
-        let mut gen = Vec::new();
-        let mut c = Storage::new(&mut ms, &mut gen);
+        let mut c = Storage::new(Box::new(MaskedStorage::new()), Box::new(Vec::new()));
 
         for i in 0..100_000 {
             c.insert(ent(i), Comp(i));
@@ -293,9 +289,7 @@ mod map_test {
 
     #[test]
     fn remove() {
-        let mut ms = MaskedStorage::new();
-        let mut gen = Vec::new();
-        let mut c = Storage::new(&mut ms, &mut gen);
+        let mut c = Storage::new(Box::new(MaskedStorage::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             c.insert(ent(i), Comp(i));
@@ -316,9 +310,7 @@ mod map_test {
 
     #[test]
     fn test_gen() {
-        let mut ms = MaskedStorage::new();
-        let mut gen = Vec::new();
-        let mut c = Storage::new(&mut ms, &mut gen);
+        let mut c = Storage::new(Box::new(MaskedStorage::new()), Box::new(Vec::new()));
 
         for i in 0..1_000i32 {
             c.insert(Entity::new(i as u32, Generation(0)), Comp(i));
@@ -332,9 +324,7 @@ mod map_test {
 
     #[test]
     fn insert_same_key() {
-        let mut ms = MaskedStorage::new();
-        let mut gen = Vec::new();
-        let mut c = Storage::new(&mut ms, &mut gen);
+        let mut c = Storage::new(Box::new(MaskedStorage::new()), Box::new(Vec::new()));
 
         for i in 0..10_000 {
             c.insert(Entity::new(i as u32, Generation(0)), Comp(i));
@@ -345,9 +335,7 @@ mod map_test {
     #[should_panic]
     #[test]
     fn wrap() {
-        let mut ms = MaskedStorage::new();
-        let mut gen = Vec::new();
-        let mut c = Storage::new(&mut ms, &mut gen);
+        let mut c = Storage::new(Box::new(MaskedStorage::new()), Box::new(Vec::new()));
 
         c.insert(Entity::new(1 << 25, Generation(0)), Comp(7));
     }
@@ -386,9 +374,7 @@ mod test {
     }
 
     fn test_add<T: Component + From<u32> + Debug + Eq>() {
-        let mut ms = MaskedStorage::<T>::new();
-        let mut gen = Vec::new();
-        let mut s = Storage::new(&mut ms, &mut gen);
+        let mut s = Storage::new(Box::new(MaskedStorage::<T>::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -400,9 +386,7 @@ mod test {
     }
 
     fn test_sub<T: Component + From<u32> + Debug + Eq>() {
-        let mut ms = MaskedStorage::<T>::new();
-        let mut gen = Vec::new();
-        let mut s = Storage::new(&mut ms, &mut gen);
+        let mut s = Storage::new(Box::new(MaskedStorage::<T>::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -415,9 +399,7 @@ mod test {
     }
 
     fn test_get_mut<T: Component + From<u32> + AsMut<u32> + Debug + Eq>() {
-        let mut ms = MaskedStorage::<T>::new();
-        let mut gen = Vec::new();
-        let mut s = Storage::new(&mut ms, &mut gen);
+        let mut s = Storage::new(Box::new(MaskedStorage::<T>::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -433,9 +415,7 @@ mod test {
     }
 
     fn test_add_gen<T: Component + From<u32> + Debug + Eq>() {
-        let mut ms = MaskedStorage::<T>::new();
-        let mut gen = Vec::new();
-        let mut s = Storage::new(&mut ms, &mut gen);
+        let mut s = Storage::new(Box::new(MaskedStorage::<T>::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -451,9 +431,7 @@ mod test {
     }
 
     fn test_sub_gen<T: Component + From<u32> + Debug + Eq>() {
-        let mut ms = MaskedStorage::<T>::new();
-        let mut gen = Vec::new();
-        let mut s = Storage::new(&mut ms, &mut gen);
+        let mut s = Storage::new(Box::new(MaskedStorage::<T>::new()), Box::new(Vec::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(2)), (i + 2718).into());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -240,14 +240,19 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
     unsafe fn get_mut(&mut self, id: Index) -> &mut T {
         self.0.get_unchecked_mut(id as usize)
     }
-    unsafe fn insert(&mut self, id: Index, v: T) {
+    unsafe fn insert(&mut self, id: Index, mut v: T) {
+        use std::mem;
         let id = id as usize;
         if self.0.len() <= id {
             let delta = id + 1 - self.0.len();
             self.0.reserve(delta);
             self.0.set_len(id + 1);
         }
-        self.0[id] = v;
+        // Can't just do `self.0[id] = v` since it would
+        // drop the existing element in there, which
+        // is undefined at this point.
+        mem::swap(self.0.get_unchecked_mut(id), &mut v);
+        mem::forget(v);
     }
     unsafe fn remove(&mut self, id: Index) -> T {
         use std::ptr;

--- a/src/world.rs
+++ b/src/world.rs
@@ -183,12 +183,9 @@ mopafy!(StorageLock);
 
 impl<T: Component> StorageLock for RwLock<MaskedStorage<T>> {
     fn del_slice(&self, entities: &[Entity]) {
-        use storage::PrivateStorage;
         let mut guard = self.write().unwrap();
         for &e in entities.iter() {
-            if guard.get_mask().contains(e.get_id()) {
-                unsafe{ guard.get_inner_mut().remove(e.get_id()) };
-            }
+            guard.remove(e.get_id());
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -3,15 +3,14 @@ use std::collections::HashMap;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use mopa::Any;
-use {Index, Generation, Entity, StorageBase, Storage};
+use {Index, Generation, Entity, StorageBase, UnprotectedStorage};
 use bitset::{AtomicBitSet, BitSet, BitSetLike, BitSetOr, MAX_EID};
 use join::{Open, Get};
-
 
 /// Abstract component type. Doesn't have to be Copy or even Clone.
 pub trait Component: Any + Sized {
     /// Associated storage type for this component.
-    type Storage: Storage<Component=Self> + Any + Send + Sync;
+    type Storage: UnprotectedStorage<Self> + Any + Send + Sync;
 }
 
 
@@ -173,6 +172,7 @@ impl<'a> Iterator for CreateEntities<'a> {
         Some(self.allocate.allocate())
     }
 }
+
 
 trait StorageLock: Any + Send + Sync {
     fn del_slice(&self, &[Entity]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate specs;
 
-use specs::{Storage, Join, Entity};
+use specs::{Join, Entity};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -193,50 +193,6 @@ fn is_alive() {
     assert!(w.is_alive(e2));
     w.delete_later(e2);
     assert!(w.is_alive(e2));
-    w.merge();
+    w.maintain();
     assert!(!w.is_alive(e2));
-}
-
-
-#[test]
-fn entities_iter() {
-    let mut w = create_world();
-    w.run_custom(|arg| {
-        let e = arg.fetch(|w| w.entities());
-        for _ in 0..10 {
-            arg.create();
-        }
-        assert!((&e,).join().count() >= 10);
-    });
-    w.run_custom(|arg| {
-        let e = arg.fetch(|w| w.entities());
-        for _ in 0..10 {
-            arg.create();
-        }
-        assert!((&e,).join().count() >= 20);
-    });
-    w.run_custom(|arg| {
-        let (e, mut bools) = arg.fetch(|w| (w.entities(), w.write::<CompBool>()));
-        for _ in 0..100 {
-            let e = arg.create();
-            bools.insert(e, CompBool(true));
-        }
-        assert!((&e,).join().count() >= 100);
-    });
-    w.run_custom(|arg| {
-        let (e, bools) = arg.fetch(|w| (w.entities(), w.read::<CompBool>()));
-        assert_eq!((&e, &bools).join().count(), 100);
-    });
-    w.run_custom(|arg| {
-        let (e, bools) = arg.fetch(|w| (w.entities(), w.read::<CompBool>()));
-        for (e, _) in (&e, &bools).join() {
-            arg.delete(e);
-        }
-    });
-    w.wait();
-    w.run_custom(|arg| {
-        let (e, bools) = arg.fetch(|w| (w.entities(), w.read::<CompBool>()));
-        assert_eq!((&e, &bools).join().count(), 0);
-        assert_eq!((&e,).join().count(), 20);
-    });
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate specs;
 
-use specs::{Join, Entity};
+use specs::{Entity};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 


### PR DESCRIPTION
Fixes #32 

Major changes:
- `BitSet` is exposed directly
- `VecStorage` and `HashMapStorage` implementations are much simpler, all the shared logic is moved up to the `MaskedStorage` and `Storage` types
- `Storage` is no longer a trait but a struct, which allows using its methods without any `use` items
- Storages no longer track the generations internally, but instead use the shared generations from the `World`
- `join` module is cleaned up by half

Performance:

| Benchmark  | specs-0.5.1 | specs-master | specs-pr |
| --------------- | --------------- | ----------------- | ----------- |
| pos_vel build | 320 us/iter (+/- 8) | 2,013 us/iter (+/- 139) |1,940 us/iter (+/- 75) |
| pos_vel update | 42 us/iter (+/- 8) | 42 us/iter (+/- 9) |42 us/iter (+/- 11) |
| parallel build | 472 us/iter (+/- 35) | 2,195 us/iter (+/- 89) |2,081 us/iter (+/- 101) |
| parallel update | 66 us/iter (+/- 11) | 64 us/iter (+/- 16) |64 us/iter (+/- 15) |