### PR TITLE
[WIP] Refactor how allocation/deletion works

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -18,7 +18,6 @@ impl specs::Component for CompBool {
 #[derive(Clone, Debug)]
 struct CompFloat(f32);
 impl specs::Component for CompFloat {
-    // HashMapStorage is better for componets that are met rarely
     type Storage = specs::VecStorage<CompFloat>;
 }
 

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -233,9 +233,9 @@ impl<'a, T> BitSetLike for &'a T where T: BitSetLike
 
 impl BitSetLike for BitSet {
     #[inline] fn layer3(&self) -> usize { self.layer3 }
-    #[inline] fn layer2(&self, i: usize) -> usize { self.layer2[i] }
-    #[inline] fn layer1(&self, i: usize) -> usize { self.layer1[i] }
-    #[inline] fn layer0(&self, i: usize) -> usize { self.layer0[i] }
+    #[inline] fn layer2(&self, i: usize) -> usize { self.layer2.get(i).map(|&x| x).unwrap_or(0) }
+    #[inline] fn layer1(&self, i: usize) -> usize { self.layer1.get(i).map(|&x| x).unwrap_or(0) }
+    #[inline] fn layer0(&self, i: usize) -> usize { self.layer0.get(i).map(|&x| x).unwrap_or(0) }
 }
 
 /// `BitSetAnd` takes two `BitSetLike` items, and merges the masks
@@ -249,6 +249,19 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetAnd<A, B> {
     #[inline] fn layer1(&self, i: usize) -> usize { self.0.layer1(i) & self.1.layer1(i) }
     #[inline] fn layer0(&self, i: usize) -> usize { self.0.layer0(i) & self.1.layer0(i) }
 }
+
+/// `BitSetOr` takes two `BitSetLike` items, and merges the masks
+/// returning a new virtual set, which represents an merged of the
+/// two original sets
+pub struct BitSetOr<A: BitSetLike, B: BitSetLike>(pub A, pub B);
+
+impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetOr<A, B> {
+    #[inline] fn layer3(&self) -> usize { self.0.layer3() | self.1.layer3() }
+    #[inline] fn layer2(&self, i: usize) -> usize { self.0.layer2(i) | self.1.layer2(i) }
+    #[inline] fn layer1(&self, i: usize) -> usize { self.0.layer1(i) | self.1.layer1(i) }
+    #[inline] fn layer0(&self, i: usize) -> usize { self.0.layer0(i) | self.1.layer0(i) }
+}
+
 
 pub struct Iter<T> {
     set: T,

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -295,6 +295,16 @@ impl<T> Iterator for Iter<T>
     }
 }
 
+/// Returns all bit as set
+pub struct BitSetAll;
+
+impl BitSetLike for BitSetAll {
+    #[inline] fn layer3(&self) -> u32 { !0 }
+    #[inline] fn layer2(&self, _: usize) -> u32 { !0 }
+    #[inline] fn layer1(&self, _: usize) -> u32 { !0 }
+    #[inline] fn layer0(&self, _: usize) -> u32 { !0 }
+}
+
 #[cfg(test)]
 mod set_test {
     use super::{BitSet, BitSetAnd, BitSetLike};

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -299,16 +299,6 @@ impl<T> Iterator for Iter<T>
     }
 }
 
-/// Returns all bit as set
-pub struct BitSetAll;
-
-impl BitSetLike for BitSetAll {
-    #[inline] fn layer3(&self) -> usize { !0 }
-    #[inline] fn layer2(&self, _: usize) -> usize { !0 }
-    #[inline] fn layer1(&self, _: usize) -> usize { !0 }
-    #[inline] fn layer0(&self, _: usize) -> usize { !0 }
-}
-
 /// This is similar to a `BitSet` but allows setting of value
 /// without unique ownership of the structure
 pub struct AtomicBitSet {
@@ -440,6 +430,21 @@ impl AtomicBitSet {
         }
         (self.layer0[p0].load(Ordering::Relaxed) & id.mask(SHIFT0)) != 0
     }
+
+    /// Clear all bits in the set
+    pub fn clear(&mut self) {
+        for l in &self.layer0[..] {
+            l.store(0, Ordering::Relaxed);
+        }
+        for l in &self.layer1[..] {
+            l.store(0, Ordering::Relaxed);
+        }
+        for l in &self.layer2[..] {
+            l.store(0, Ordering::Relaxed);
+        }
+        self.layer3.store(0, Ordering::Relaxed);
+    }
+
 }
 
 impl BitSetLike for AtomicBitSet {

--- a/src/join.rs
+++ b/src/join.rs
@@ -108,8 +108,6 @@ impl<'b, 'a:'b, T> Open for &'b mut std::sync::RwLockWriteGuard<'a, T>
     }
 }
 
-
-
 /// Get like `Open` provides the same feature of providing
 /// mutable vs immutable preserving around the UnprotectedStorage
 /// trait

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use threadpool::ThreadPool;
 
 pub use storage::{Storage, StorageBase, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
-    EntityBuilder, EntityIter, CreateEntityIter};
+    EntityBuilder, Entities, CreateEntities};
 pub use bitset::{BitSetAnd, BitSet, BitSetLike};
 pub use join::Join;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,6 @@ impl Generation {
         debug_assert!(!self.is_alive());
         Generation(1 - self.0)
     }
-
-    /// Returns `true` if this is a first generation, i.e. has value `1`.
-    fn is_first(&self) -> bool {
-        self.0 == 1
-    }
 }
 
 /// `Index` type is arbitrary. It doesn't show up in any interfaces.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use threadpool::ThreadPool;
 
 pub use storage::{Storage, StorageBase, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
-    EntityBuilder, EntityIter, CreateEntityIter, DynamicEntityIter};
+    EntityBuilder, EntityIter, CreateEntityIter};
 pub use bitset::{BitSetAnd, BitSet, BitSetLike};
 pub use join::Join;
 
@@ -107,10 +107,6 @@ impl RunArg {
     /// Deletes an entity dynamically.
     pub fn delete(&self, entity: Entity) {
         self.world.delete_later(entity)
-    }
-    /// Returns an iterator over dynamically added entities.
-    pub fn new_entities(&self) -> DynamicEntityIter {
-        self.world.dynamic_entities()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use threadpool::ThreadPool;
 pub use storage::{Storage, StorageBase, VecStorage, HashMapStorage, UnprotectedStorage};
 pub use world::{Component, World, FetchArg,
     EntityBuilder, Entities, CreateEntities};
-pub use bitset::{BitSetAnd, BitSet, BitSetLike};
+pub use bitset::{BitSetAnd, BitSet, BitSetLike, AtomicBitSet};
 pub use join::Join;
 
 mod storage;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -345,7 +345,7 @@ mod map_test {
     #[test]
     fn wrap() {
         let mut c = VecStorage::new();
-        c.insert(Entity::new(1 << 21, Generation(0)), 7);
+        c.insert(Entity::new(1 << 25, Generation(0)), 7);
     }
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -95,22 +95,6 @@ impl<'a> Iterator for CreateEntityIter<'a> {
     }
 }
 
-/// A custom entity iterator for dynamically added entities.
-pub struct DynamicEntityIter<'a> {
-    guard: RwLockReadGuard<'a, Appendix>,
-    index: usize,
-}
-
-impl<'a> Iterator for DynamicEntityIter<'a> {
-    type Item = Entity;
-    fn next(&mut self) -> Option<Entity> {
-        let ent = self.guard.add_queue.get(self.index);
-        self.index += 1;
-        ent.cloned()
-    }
-}
-
-
 trait StorageLock: Any + Send + Sync {
     fn del_slice(&self, &[Entity]);
 }
@@ -179,14 +163,6 @@ impl World {
     pub fn entities(&self) -> EntityIter {
         EntityIter {
             guard: self.generations.read().unwrap(),
-            index: 0,
-        }
-    }
-    /// Returns the dynamic entity iterator. It iterates over entities that were
-    /// dynamically created by systems but not yet merged.
-    pub fn dynamic_entities(&self) -> DynamicEntityIter {
-        DynamicEntityIter {
-            guard: self.appendix.read().unwrap(),
             index: 0,
         }
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -35,15 +35,10 @@ impl<'a> Open for &'a Entities<'a> {
 impl<'a> Get for &'a Entities<'a> {
     type Value = Entity;
     unsafe fn get(&self, idx: Index) -> Self::Value {
-        if let Some(&gen) = self.guard.generations.get(idx as usize) {
-            if gen.is_alive() {
-                Entity(idx, gen)
-            } else {
-                Entity(idx, gen.raised())
-            }
-        } else {
-            Entity(idx, Generation(1))
-        }
+        let gen = self.guard.generations.get(idx as usize)
+            .map(|&gen| if gen.is_alive() { gen } else { gen.raised() })
+            .unwrap_or(Generation(1));
+        Entity(idx, gen)
     }
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -4,7 +4,7 @@ use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use mopa::Any;
 use {Index, Generation, Entity, StorageBase, Storage};
-use bitset::{AtomicBitSet, BitSet, BitSetLike, BitSetOr};
+use bitset::{AtomicBitSet, BitSet, BitSetLike, BitSetOr, MAX_EID};
 use join::{Open, Get};
 
 
@@ -71,8 +71,8 @@ impl Allocator {
         Allocator {
             generations: vec![],
             alive: BitSet::new(),
-            raised: AtomicBitSet::with_capacity(1_000_000),
-            killed: AtomicBitSet::with_capacity(1_000_000),
+            raised: AtomicBitSet::with_capacity(MAX_EID as u32),
+            killed: AtomicBitSet::with_capacity(MAX_EID as u32),
             start_from: AtomicUsize::new(0)
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate specs;
 
-use specs::{Storage, Join};
+use specs::{Storage, Join, Entity};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -141,6 +141,43 @@ fn dynamic_create_and_delete() {
         planner.wait();
         swap(&mut ent1, &mut ent0)
     }
+}
+
+#[test]
+fn mixed_create_merge() {
+    use std::collections::HashSet;
+    let mut planner = create_world();
+    let mut set = HashSet::new();
+
+    let add = |set: &mut HashSet<Entity>, e: Entity| {
+        assert!(!set.contains(&e));
+        set.insert(e);
+    };
+
+    let insert = |planner: &mut specs::Planner<()>, set: &mut HashSet<Entity>, cnt: usize| {
+        // Check to make sure there is no conflict between create_now
+        // and create_later
+        for _ in 0..10 {
+            for _ in 0..cnt {
+                add(set, planner.world.create_now().build());
+                add(set, planner.world.create_later());
+                //  swap order
+                add(set, planner.world.create_later());
+                add(set, planner.world.create_now().build());
+            }
+            planner.wait();
+        }
+    };
+
+    insert(&mut planner, &mut set, 10);
+    for e in set.drain() {
+        planner.world.delete_later(e);
+    }
+    insert(&mut planner, &mut set, 20);
+    for e in set.drain() {
+        planner.world.delete_now(e);
+    }
+    insert(&mut planner, &mut set, 40);
 }
 
 #[test]


### PR DESCRIPTION
- The DynamicEntityIter is removed
- Allocation / Deletion can be done without a write lock
- Add the ability to `Join` over the `entities()`

This removes the `add_list/sub_list` in-favour of atomic bit sets. Killing an Entity sets a bit atomically that can be looked up later during the merge. Raising a dead entity is done via an atomic bitset too. This allows systems to iterate over the entities without blocking system that need to create or delete entities.

The other big part of this change is that the functionality of the DynamicEntityIter & the EntitiyIter are now in one place. We merge the known alive entity ids, with any raised entities. The `Entities` can see entities that are created by systems in parallel, which might cause some unpredictable behaviour. But if you are masking with a component (that is locked upstream) it still reliably work.