### PR TITLE
Return the old value during a insert.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use pulse::{Pulse, Signal, Signals};
 use threadpool::ThreadPool;
 
 pub use storage::{Storage, UnprotectedStorage, AntiStorage,
-                  VecStorage, HashMapStorage, NullStorage};
+                  VecStorage, HashMapStorage, NullStorage, InsertResult};
 pub use world::{Component, World, EntityBuilder, Entities, CreateEntities};
 pub use join::{Join, JoinIter};
 


### PR DESCRIPTION
This makes the storage api closer to the rust api, and allows for a more efficient logging of changes. IE a changefeed that works on-top of the of specs.

This is an api breaking change.