### PR TITLE
Exported all types need for the return types of World::read() and World::write()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,10 @@ use pulse::{Pulse, Signal, Signals};
 use threadpool::ThreadPool;
 
 pub use storage::{Storage, UnprotectedStorage, AntiStorage,
-                  VecStorage, HashMapStorage, NullStorage, InsertResult};
-pub use world::{Component, World, EntityBuilder, Entities, CreateEntities};
+                  VecStorage, HashMapStorage, NullStorage, InsertResult,
+                  MaskedStorage};
+pub use world::{Component, World, EntityBuilder, Entities, CreateEntities,
+                Allocator};
 pub use join::{Join, JoinIter};
 
 mod storage;

--- a/src/world.rs
+++ b/src/world.rs
@@ -56,8 +56,8 @@ impl<'a> EntityBuilder<'a> {
 
 
 /// Internally used structure for `Entity` allocation.
-#[doc(hidden)]
 pub struct Allocator {
+    #[doc(hidden)]
     pub generations: Vec<Generation>,
     alive: BitSet,
     raised: AtomicBitSet,
@@ -66,6 +66,7 @@ pub struct Allocator {
 }
 
 impl Allocator {
+    #[doc(hidden)]
     pub fn new() -> Allocator {
         Allocator {
             generations: vec![],


### PR DESCRIPTION
This is needed to write out the types in, eg, a struct.