### PR TITLE
debug free of vec storage

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -262,10 +262,10 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
         VecStorage(Vec::new())
     }
     unsafe fn clean<F>(&mut self, has: F) where F: Fn(Index) -> bool {
-        use std::mem;
+        use std::ptr;
         for (i, v) in self.0.iter_mut().enumerate() {
             if has(i as Index) {
-                mem::swap(v, &mut mem::uninitialized());
+                ptr::drop_in_place(v);
             }
         }
         self.0.set_len(0);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -263,13 +263,12 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
     }
     unsafe fn clean<F>(&mut self, has: F) where F: Fn(Index) -> bool {
         use std::mem;
-        for (i, v) in self.0.drain(..).enumerate() {
-            if !has(i as Index) {
-                // if v was not in the set the data is invalid
-                // and we must forget it instead of dropping it
-                mem::forget(v);
+        for (i, v) in self.0.iter_mut().enumerate() {
+            if has(i as Index) {
+                mem::swap(v, &mut mem::uninitialized());
             }
         }
+        self.0.set_len(0);
     }
     unsafe fn get(&self, id: Index) -> &T {
         self.0.get_unchecked(id as usize)
@@ -409,6 +408,21 @@ mod map_test {
     }
 }
 
+#[test]
+fn test_vec_arc() {
+    use std::sync::Arc;
+
+    struct A(Arc<()>);
+
+    let mut storage = VecStorage::<A>::new();
+
+    unsafe {
+        for i in (0..200).filter(|i| i%2 != 0) {
+            storage.insert(i, A(Arc::new(())));
+        }
+        storage.clean(|i| i%2 != 0);
+    }
+}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
as mentioned in the issue #73 the drain iterator doesn't iterate
correctly on this unsafe inserted vector.
I don't know if it is expected and I will post the question on forums soon.

this commit contains a test that failed in past and an
implementation that pass this test.

basically it cleans the vector like it fills it by swapping value to drop
them and then set it len to 0

closes #73