### PR TITLE
Add rudimentary message passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs"
-version = "0.7.0"
+version = "0.8.0"
 description = """
 Parallel Entity-Component System.
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -51,7 +51,7 @@ fn main() {
         w.add_resource(Sum(0xdeadbeef));
 
         // Planner is used to run systems on the specified world with a specified number of threads
-        (e, specs::Planner::<()>::new(w, 4))
+        (e, specs::Planner::<(),()>::new(w, 4))
     };
 
     // Planner only runs closure on entites with specified components, for example:

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -2,7 +2,7 @@ extern crate specs;
 
 #[cfg(feature="parallel")]
 mod msg_example {
-    use specs::{RunArg, System, MessageQueue};
+    use specs::{RunArg, System, MessageQueue, World};
 
     #[derive(Clone, Debug)]
     pub enum Message {
@@ -17,7 +17,7 @@ mod msg_example {
             msg.send(Message::Hello("hey".to_owned()));
         }
 
-        fn handle_message(&mut self, msg: &Message) {
+        fn handle_message(&mut self, _: &mut World, msg: &Message) {
             use self::Message::*;
             match *msg {
                 Hello(_) => println!("Got a hello!"),
@@ -33,7 +33,7 @@ mod msg_example {
             msg.send(Message::Goodbye("bye".to_owned()));
         }
 
-        fn handle_message(&mut self, msg: &Message) {
+        fn handle_message(&mut self, _: &mut World, msg: &Message) {
             use self::Message::*;
             match *msg {
                 Hello(_) => (),
@@ -54,7 +54,7 @@ mod msg_example {
             println!("I have seen {} goodbyes.", self.goodbye);
         }
 
-        fn handle_message(&mut self, msg: &Message) {
+        fn handle_message(&mut self, _: &mut World, msg: &Message) {
             use self::Message::*;
             match *msg {
                 Hello(_) => self.hello += 1,

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -1,72 +1,83 @@
 extern crate specs;
-use specs::{RunArg, System, MessageQueue};
 
-#[derive(Clone, Debug)]
-enum Message {
-    Hello(String),
-    Goodbye(String),
-}
+#[cfg(feature="parallel")]
+mod msg_example {
+    use specs::{RunArg, System, MessageQueue};
 
-struct HelloSystem {}
-impl System<Message, ()> for HelloSystem {
-    fn run(&mut self, arg: RunArg, msg: MessageQueue<Message>, _: ()) {
-        let _ = arg.fetch(|_|{});
-        msg.send(Message::Hello("hey".to_owned()));
+    #[derive(Clone, Debug)]
+    pub enum Message {
+        Hello(String),
+        Goodbye(String),
     }
 
-    fn handle_message(&mut self, msg: &Message) {
-        use Message::*;
-        match *msg {
-            Hello(_) => println!("Got a hello!"),
-            Goodbye(_) => (),
+    pub struct HelloSystem {}
+    impl System<Message, ()> for HelloSystem {
+        fn run(&mut self, arg: RunArg, msg: MessageQueue<Message>, _: ()) {
+            let _ = arg.fetch(|_|{});
+            msg.send(Message::Hello("hey".to_owned()));
+        }
+
+        fn handle_message(&mut self, msg: &Message) {
+            use self::Message::*;
+            match *msg {
+                Hello(_) => println!("Got a hello!"),
+                Goodbye(_) => (),
+            }
         }
     }
-}
 
-struct GoodbyeSystem {}
-impl System<Message, ()> for GoodbyeSystem {
-    fn run(&mut self, arg: RunArg, msg: MessageQueue<Message>, _: ()) {
-        let _ = arg.fetch(|_|{});
-        msg.send(Message::Goodbye("bye".to_owned()));
-    }
+    pub struct GoodbyeSystem {}
+    impl System<Message, ()> for GoodbyeSystem {
+        fn run(&mut self, arg: RunArg, msg: MessageQueue<Message>, _: ()) {
+            let _ = arg.fetch(|_|{});
+            msg.send(Message::Goodbye("bye".to_owned()));
+        }
 
-    fn handle_message(&mut self, msg: &Message) {
-        use Message::*;
-        match *msg {
-            Hello(_) => (),
-            Goodbye(_) => println!("Got a goodbye!"),
+        fn handle_message(&mut self, msg: &Message) {
+            use self::Message::*;
+            match *msg {
+                Hello(_) => (),
+                Goodbye(_) => println!("Got a goodbye!"),
+            }
         }
     }
-}
 
-struct GreetzCounter {
-    hello: u32,
-    goodbye: u32,
-}
-
-impl System<Message, ()> for GreetzCounter {
-    fn run(&mut self, arg: RunArg, _: MessageQueue<Message>, _: ()) {
-        let _ = arg.fetch(|_|{});
-        println!("I have seen {} hellos.", self.hello);
-        println!("I have seen {} goodbyes.", self.goodbye);
+    pub struct GreetzCounter {
+        pub hello: u32,
+        pub goodbye: u32,
     }
 
-    fn handle_message(&mut self, msg: &Message) {
-        use Message::*;
-        match *msg {
-            Hello(_) => self.hello += 1,
-            Goodbye(_) => self.goodbye += 1,
+    impl System<Message, ()> for GreetzCounter {
+        fn run(&mut self, arg: RunArg, _: MessageQueue<Message>, _: ()) {
+            let _ = arg.fetch(|_|{});
+            println!("I have seen {} hellos.", self.hello);
+            println!("I have seen {} goodbyes.", self.goodbye);
+        }
+
+        fn handle_message(&mut self, msg: &Message) {
+            use self::Message::*;
+            match *msg {
+                Hello(_) => self.hello += 1,
+                Goodbye(_) => self.goodbye += 1,
+            }
         }
     }
+
 }
+
+#[cfg(not(feature="parallel"))]
+fn main() {
+}
+
+#[cfg(feature="parallel")]
 fn main() {
     let mut planner = {
         let w = specs::World::new();
-        specs::Planner::<Message,()>::new(w, 4)
+        specs::Planner::<msg_example::Message,()>::new(w, 4)
     };
-    let h = HelloSystem {};
-    let g = GoodbyeSystem {};
-    let ctr = GreetzCounter { hello: 0, goodbye: 0 };
+    let h = msg_example::HelloSystem {};
+    let g = msg_example::GoodbyeSystem {};
+    let ctr = msg_example::GreetzCounter { hello: 0, goodbye: 0 };
 
     planner.add_system(h, "hello", 1);
     planner.add_system(g, "goodbye", 2);

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -1,0 +1,81 @@
+extern crate specs;
+use specs::{RunArg, System, MessageQueue};
+
+#[derive(Clone, Debug)]
+enum Message {
+    Hello(String),
+    Goodbye(String),
+}
+
+struct HelloSystem {}
+impl System<Message, ()> for HelloSystem {
+    fn run(&mut self, arg: RunArg, msg: MessageQueue<Message>, _: ()) {
+        let _ = arg.fetch(|_|{});
+        msg.send(Message::Hello("hey".to_owned()));
+    }
+
+    fn handle_message(&mut self, msg: &Message) {
+        use Message::*;
+        match *msg {
+            Hello(_) => println!("Got a hello!"),
+            Goodbye(_) => (),
+        }
+    }
+}
+
+struct GoodbyeSystem {}
+impl System<Message, ()> for GoodbyeSystem {
+    fn run(&mut self, arg: RunArg, msg: MessageQueue<Message>, _: ()) {
+        let _ = arg.fetch(|_|{});
+        msg.send(Message::Goodbye("bye".to_owned()));
+    }
+
+    fn handle_message(&mut self, msg: &Message) {
+        use Message::*;
+        match *msg {
+            Hello(_) => (),
+            Goodbye(_) => println!("Got a goodbye!"),
+        }
+    }
+}
+
+struct GreetzCounter {
+    hello: u32,
+    goodbye: u32,
+}
+
+impl System<Message, ()> for GreetzCounter {
+    fn run(&mut self, arg: RunArg, _: MessageQueue<Message>, _: ()) {
+        let _ = arg.fetch(|_|{});
+        println!("I have seen {} hellos.", self.hello);
+        println!("I have seen {} goodbyes.", self.goodbye);
+    }
+
+    fn handle_message(&mut self, msg: &Message) {
+        use Message::*;
+        match *msg {
+            Hello(_) => self.hello += 1,
+            Goodbye(_) => self.goodbye += 1,
+        }
+    }
+}
+fn main() {
+    let mut planner = {
+        let w = specs::World::new();
+        specs::Planner::<Message,()>::new(w, 4)
+    };
+    let h = HelloSystem {};
+    let g = GoodbyeSystem {};
+    let ctr = GreetzCounter { hello: 0, goodbye: 0 };
+
+    planner.add_system(h, "hello", 1);
+    planner.add_system(g, "goodbye", 2);
+    planner.add_system(ctr, "greetz", 3);
+
+    for _ in 0..3 {
+        planner.dispatch(());
+        // technically not necessary; we call wait in handle_messages
+        planner.wait();
+        planner.handle_messages();
+    }
+}

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -125,7 +125,7 @@ pub struct Planner<M, C> {
     wait_count: usize,
     chan_out: mpsc::Sender<SystemInfo<M, C>>,
     chan_in: mpsc::Receiver<SystemInfo<M, C>>,
-    message_out: MessageQueue<M>,
+    pub message_out: MessageQueue<M>,
     message_in: mpsc::Receiver<M>,
     threader: ThreadPool,
 }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -125,6 +125,7 @@ pub struct Planner<M, C> {
     wait_count: usize,
     chan_out: mpsc::Sender<SystemInfo<M, C>>,
     chan_in: mpsc::Receiver<SystemInfo<M, C>>,
+    /// Message queue for sending messages to systems in the planner.
     pub message_out: MessageQueue<M>,
     message_in: mpsc::Receiver<M>,
     threader: ThreadPool,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate specs;
 
-use specs::{Entity, Join, MessageQueue, RunArg, System};
+use specs::{Entity, Join};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -303,6 +303,8 @@ fn dynamic_component() {
 #[cfg(feature = "parallel")]
 #[test]
 fn handle_message_self() {
+    use specs::{MessageQueue, RunArg, System};
+
     #[derive(Clone, Debug)]
     struct Msg {
         pub x: i8,
@@ -350,6 +352,7 @@ fn handle_message_self() {
 #[cfg(feature = "parallel")]
 #[test]
 fn handle_message_two() {
+    use specs::{MessageQueue, RunArg, System};
 
     #[derive(Clone, Debug)]
     enum Msg {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate specs;
 
-use specs::{Entity};
+use specs::{Entity, Join, MessageQueue, RunArg, System};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -16,7 +16,7 @@ impl specs::Component for CompBool {
 }
 
 #[cfg(feature="parallel")]
-fn create_world() -> specs::Planner<()> {
+fn create_world() -> specs::Planner<(), ()> {
     let mut w = specs::World::new();
     w.register::<CompInt>();
     w.register::<CompBool>();
@@ -162,7 +162,7 @@ fn mixed_create_merge() {
         set.insert(e);
     };
 
-    let insert = |planner: &mut specs::Planner<()>, set: &mut HashSet<Entity>, cnt: usize| {
+    let insert = |planner: &mut specs::Planner<(), ()>, set: &mut HashSet<Entity>, cnt: usize| {
         // Check to make sure there is no conflict between create_now
         // and create_later
         for _ in 0..10 {
@@ -226,7 +226,7 @@ fn stillborn_entities() {
     let mut rng = LCG::new();
 
     // Construct a bunch of entities
-    let mut planner = specs::Planner::<()>::new({
+    let mut planner = specs::Planner::<(), ()>::new({
         let mut world = specs::World::new();
         world.register::<CompInt>();
 
@@ -298,4 +298,126 @@ fn dynamic_component() {
 
     let c = w.read_w_comp_id::<CompBool>(2).get(e).unwrap().0;
     assert_eq!(c, true);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn handle_message_self() {
+    #[derive(Clone, Debug)]
+    struct Msg {
+        pub x: i8,
+    }
+
+    struct MsgSystem {
+        pub last_msg: i8,
+    }
+
+    impl System<Msg, ()> for MsgSystem {
+        fn run(&mut self, arg: RunArg, m: MessageQueue<Msg>, _: ()) {
+
+            let mut ints = arg.fetch(|w|{w.write::<CompInt>()});
+            for c in (&mut ints).iter() {
+                c.0 = self.last_msg;
+            }
+
+            m.send(Msg { x: self.last_msg+1 });
+        }
+        fn handle_message(&mut self, msg: &Msg) {
+            self.last_msg = msg.x;
+        }
+    }
+
+    let mut planner = {
+        let mut w = specs::World::new();
+        w.register::<CompInt>();
+        specs::Planner::new(w, 4)
+    };
+
+    let e = planner.mut_world().create_now()
+        .with(CompInt(0))
+        .build();
+
+    planner.add_system( MsgSystem {last_msg: 0}, "msgtest", 1 );
+
+    for _ in 0..3 {
+        planner.dispatch(());
+        planner.handle_messages();
+    }
+
+    assert_eq!(2, planner.mut_world().read::<CompInt>().get(e).unwrap().0);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn handle_message_two() {
+
+    #[derive(Clone, Debug)]
+    enum Msg {
+        Ping,
+        Pong
+    }
+
+    #[derive(Clone, Debug)]
+    struct PingData(u32);
+
+    #[derive(Clone, Debug)]
+    struct PongData(u32);
+
+    struct PingSystem {
+        pub pongs: u32,
+    }
+
+    impl System<Msg, ()> for PingSystem {
+        fn run(&mut self, arg: RunArg, m: MessageQueue<Msg>, _: ()) {
+            let mut p = arg.fetch(|w|{w.write_resource::<PongData>()});
+            p.0 = self.pongs;
+            m.send(Msg::Ping);
+        }
+        fn handle_message(&mut self, msg: &Msg) {
+            match *msg {
+                Msg::Ping => (),
+                Msg::Pong => self.pongs+=1,
+            }
+        }
+    }
+
+    struct PongSystem {
+        pub pings: u32,
+    }
+
+    impl System<Msg, ()> for PongSystem {
+        fn run(&mut self, arg: RunArg, m: MessageQueue<Msg>, _: ()) {
+            let mut p = arg.fetch(|w|{w.write_resource::<PingData>()});
+            p.0 = self.pings;
+            m.send(Msg::Pong);
+        }
+        fn handle_message(&mut self, msg: &Msg) {
+            match *msg {
+                Msg::Ping => self.pings+=1,
+                Msg::Pong => (),
+            }
+        }
+    }
+
+    let mut planner = {
+        let mut w = specs::World::new();
+        w.add_resource(PingData(0));
+        w.add_resource(PongData(0));
+        specs::Planner::new(w, 4)
+    };
+
+    let ping = PingSystem {pongs: 0};
+    let pong = PongSystem {pings: 0};
+    planner.add_system(ping, "ping", 1 );
+    planner.add_system(pong, "pong", 1 );
+
+    for _ in 0..3 {
+        planner.dispatch(());
+        planner.handle_messages();
+    }
+
+    // this is two because even though self.p{i,o}ngs is 3,
+    // it only updates the world resource in run(), in the next frame.
+    assert_eq!(planner.mut_world().read_resource::<PingData>().0, 2);
+    assert_eq!(planner.mut_world().read_resource::<PongData>().0, 2);
 }


### PR DESCRIPTION
I wanted to use message passing with specs but it was a bit difficult to use externally to the planner; once you give the systems over to it, you can only access them via the System trait.

Please tear this code apart and feel free to reject the PR completely if you guys think it's too limited or not useful enough. In particular, I'm not sure if the message handlers should have access to the world/entities/resources. It probably would be useful to have access to the resources at least.

The current code isn't quite zero-cost if you don't use it: I updated the basic.rs example and I only needed to change one line, but inside Planner::dispatch I do a clone on a mpsc::Sender<M> even if M is e.g. ().

The alternative to this PR is to add a Sender to your Context struct, and then at the end of each frame gather all the messages into an Vec<Message> and including a const ref to that in your Context struct as well. This makes message handling much more ad-hoc and precludes doing optimizations in handle_messages.

Caveat: messages are not currently handled in parallel, but they could be in the same way as Planner::dispatch. I think it could be a good use case for rayon's ParallelIterator.