### PR TITLE
Documentation spelling/grammar fixes

### DIFF
--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -82,8 +82,8 @@ impl BitSet {
         }
     }
 
-    /// this is used to set the levels in the hierarchy
-    /// when the lowest layer was set from 0
+    /// This is used to set the levels in the hierarchy
+    /// when the lowest layer was set from 0.
     #[inline(never)]
     fn add_slow(&mut self, id: Index) {
         let (_, p1, p2) = offsets(id);

--- a/src/join.rs
+++ b/src/join.rs
@@ -4,7 +4,7 @@ use bitset::{BitIter, BitSetAnd, BitSetLike};
 use Index;
 
 
-/// BitAnd is a helper method to & bitsets togather resulting in a tree
+/// BitAnd is a helper method to & bitsets together resulting in a tree.
 pub trait BitAnd {
     type Value: BitSetLike;
     fn and(self) -> Self::Value;
@@ -71,7 +71,7 @@ pub trait Join {
     }
     /// Open this join by returning the mask and the storages.
     fn open(self) -> (Self::Mask, Self::Value);
-    /// Get a joined component value by a gien index.
+    /// Get a joined component value by a given index.
     unsafe fn get(&mut Self::Value, Index) -> Self::Type;
 }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -61,7 +61,7 @@ impl<C> System<C> for () {
     fn run(&mut self, _: RunArg, _: C) {}
 }
 
-/// System scheduling priority. Higehr priority systems are started
+/// System scheduling priority. Higher priority systems are started
 /// earlier than lower-priority ones.
 pub type Priority = i32;
 
@@ -159,7 +159,7 @@ impl<C: 'static> Planner<C> {
         }
     }
 
-    /// Waits for all currently executing systems to finish, and then
+    /// Waits for all currently executing systems to finish and then
     /// returns the mutable borrow of the world, allowing to create
     /// entities instantly.
     pub fn mut_world(&mut self) -> &mut World {
@@ -167,7 +167,7 @@ impl<C: 'static> Planner<C> {
         Arc::get_mut(&mut self.world).unwrap()
     }
 
-    /// Waits for all currently executing systems to finish, and then
+    /// Waits for all currently executing systems to finish and then
     /// merges all queued changes.
     pub fn wait(&mut self) {
         self.mut_world().maintain();

--- a/src/world.rs
+++ b/src/world.rs
@@ -23,7 +23,7 @@ pub trait Component: Any + Sized {
 /// is lazily created and updated. For this to be useful it _must_
 /// be joined with a component. This is because the Generation table
 /// includes every possible Generation of Entities even if they
-/// have never been
+/// have never existed.
 pub struct Entities<'a> {
     guard: RwLockReadGuard<'a, Allocator>,
 }
@@ -342,16 +342,16 @@ impl<C> World<C>
             comp.del_slice(&temp_list);
         }
     }
-    /// add a new resource to the world
+    /// Add a new resource to the world.
     pub fn add_resource<T: Any+Send+Sync>(&mut self, resource: T) {
         let resource = Box::new(RwLock::new(resource));
         self.resources.insert(TypeId::of::<T>(), resource);
     }
-    /// check to see if a resource is present
+    /// Check to see if a resource is present.
     pub fn has_resource<T: Any+Send+Sync>(&self) -> bool {
         self.resources.get(&TypeId::of::<T>()).is_some()
     }
-    /// get read-only access to an resource
+    /// Get read-only access to an resource.
     pub fn read_resource<T: Any+Send+Sync>(&self) -> RwLockReadGuard<T> {
         self.resources.get(&TypeId::of::<T>())
             .expect("Resource was not registered")
@@ -360,7 +360,7 @@ impl<C> World<C>
             .read()
             .unwrap()
     }
-    /// get read-write access to a resource
+    /// Get read-write access to a resource.
     pub fn write_resource<T: Any+Send+Sync>(&self) -> RwLockWriteGuard<T> {
         self.resources.get(&TypeId::of::<T>())
             .expect("Resource was not registered")


### PR DESCRIPTION
Just some various spelling and grammar fixes to the documentation for consistency with other documentation.