### PR TITLE
Implement Deref/Mut for Storage

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -136,9 +136,6 @@ impl<T, A, D> Storage<T, A, D> where
     }
 }
 
-
-
-
 /// the status of an insert operation
 pub enum InsertResult<T> {
     /// The value was inserted and there was no value before

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -348,7 +348,7 @@ mod map_test {
 
     #[test]
     fn insert() {
-        let mut c = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
+        let mut c: Storage<Comp<u32>, _, _> = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
 
         for i in 0..1_000 {
             c.insert(ent(i), Comp(i));
@@ -361,7 +361,7 @@ mod map_test {
 
     #[test]
     fn insert_100k() {
-        let mut c = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
+        let mut c: Storage<Comp<u32>, _, _> = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
 
         for i in 0..100_000 {
             c.insert(ent(i), Comp(i));
@@ -374,7 +374,7 @@ mod map_test {
 
     #[test]
     fn remove() {
-        let mut c = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
+        let mut c: Storage<Comp<u32>, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
 
         for i in 0..1_000 {
             c.insert(ent(i), Comp(i));
@@ -395,7 +395,7 @@ mod map_test {
 
     #[test]
     fn test_gen() {
-        let mut c = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
+        let mut c: Storage<Comp<i32>, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
 
         for i in 0..1_000i32 {
             c.insert(ent(i as u32), Comp(i));
@@ -409,7 +409,7 @@ mod map_test {
 
     #[test]
     fn insert_same_key() {
-        let mut c = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
+        let mut c: Storage<Comp<u32>, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
 
         for i in 0..10_000 {
             c.insert(ent(i), Comp(i));
@@ -420,7 +420,7 @@ mod map_test {
     #[should_panic]
     #[test]
     fn wrap() {
-        let mut c = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
+        let mut c: Storage<Comp<u32>, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::new()));
 
         c.insert(ent(1 << 25), Comp(7));
     }
@@ -491,7 +491,7 @@ mod test {
     }
 
     fn test_add<T: Component + From<u32> + Debug + Eq>() {
-        let mut s = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
+        let mut s: Storage<T, _, _> = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -503,7 +503,7 @@ mod test {
     }
 
     fn test_sub<T: Component + From<u32> + Debug + Eq>() {
-        let mut s = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
+        let mut s: Storage<T, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -516,7 +516,7 @@ mod test {
     }
 
     fn test_get_mut<T: Component + From<u32> + AsMut<u32> + Debug + Eq>() {
-        let mut s = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
+        let mut s: Storage<T, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -532,7 +532,7 @@ mod test {
     }
 
     fn test_add_gen<T: Component + From<u32> + Debug + Eq>() {
-        let mut s = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
+        let mut s: Storage<T, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(1)), (i + 2718).into());
@@ -546,7 +546,7 @@ mod test {
     }
 
     fn test_sub_gen<T: Component + From<u32> + Debug + Eq>() {
-        let mut s = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
+        let mut s: Storage<T, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
 
         for i in 0..1_000 {
             s.insert(Entity::new(i, Generation(2)), (i + 2718).into());
@@ -558,7 +558,7 @@ mod test {
     }
 
     fn test_clear<T: Component + From<u32>>() {
-        let mut s = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
+        let mut s: Storage<T, _, _>  = Storage::new(Box::new(Allocator::new()), Box::new(MaskedStorage::<T>::new()));
 
         for i in 0..10 {
             s.insert(Entity::new(i, Generation(1)), (i + 10).into());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -91,6 +91,27 @@ impl<'a, T, A, D> Not for &'a Storage<T, A, D> where
     }
 }
 
+impl<T, A, D> Deref for Storage<T, A, D> where
+    T: Component,
+    A: Deref<Target = Allocator>,
+    D: Deref<Target = MaskedStorage<T>>,
+{
+    type Target = T::Storage;
+    fn deref(&self) -> &T::Storage {
+        &self.data.inner
+    }
+}
+
+impl<T, A, D> DerefMut for Storage<T, A, D> where
+    T: Component,
+    A: Deref<Target = Allocator>,
+    D: DerefMut<Target = MaskedStorage<T>>,
+{
+    fn deref_mut(&mut self) -> &mut T::Storage {
+        &mut self.data.inner
+    }
+}
+
 impl<T, A, D> Storage<T, A, D> {
     /// Create a new `Storage`
     pub fn new(alloc: A, data: D) -> Storage<T, A, D>{
@@ -114,6 +135,8 @@ impl<T, A, D> Storage<T, A, D> where
         }else {None}
     }
 }
+
+
 
 
 /// the status of an insert operation


### PR DESCRIPTION
Allows access to `T::Storage`'s methods from the `Storage<T, A, D>`. Makes specs somewhat easier to use by removing the requirement to get the actual storage before calling any methods on the inner storage.

```rust
let (storage) = arg.fetch(|w| w.write::<Component>());
storage.method();
```
is the equivalent of
```rust
let (storage) = arg.fetch(|w| w.write::<Component>());
let actual_storage = storage.open().1;
actual_storage.method();
```

Pros:
- Easier to call methods on inner storages as well as getting values. (no need for opening the storage).

Cons:
- Introduces more ambiguity to the compiler leading to some cases requiring more explicit typing.