### PR TITLE
FlaggedStorage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ extern crate mopa;
 extern crate shred;
 extern crate tuple_utils;
 
+<<<<<<< HEAD
 #[cfg(feature="serialize")]
 extern crate serde;
 #[cfg(feature="serialize")]
@@ -140,6 +141,13 @@ extern crate serde_derive;
 pub use shred::{AsyncDispatcher, Dispatcher, DispatcherBuilder, Resource, System, run_now};
 
 pub use entity::{Component, Entity, Entities};
+=======
+pub use storage::{Storage, UnprotectedStorage, AntiStorage,
+                  VecStorage, HashMapStorage, NullStorage, InsertResult,
+                  MaskedStorage, TrackedStorage};
+pub use world::{Component, World, EntityBuilder, Entities, CreateEntities,
+                Allocator};
+>>>>>>> 700efc8... Join implementations for TrackedStorage, some documentation
 pub use join::{Join, JoinIter};
 pub use world::World;
 pub use storage::{CheckStorage, InsertResult, UnprotectedStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ pub mod prelude {
 
     pub use data::{Entities, Fetch, FetchMut, ReadStorage, WriteStorage};
     pub use join::Join;
-    pub use storages::{DenseVecStorage, HashMapStorage, VecStorage, TrackedStorage};
+    pub use storages::{DenseVecStorage, HashMapStorage, VecStorage, FlaggedStorage};
 }
 
 pub use storage::storages;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@ extern crate mopa;
 extern crate shred;
 extern crate tuple_utils;
 
-<<<<<<< HEAD
 #[cfg(feature="serialize")]
 extern crate serde;
 #[cfg(feature="serialize")]
@@ -141,13 +140,6 @@ extern crate serde_derive;
 pub use shred::{AsyncDispatcher, Dispatcher, DispatcherBuilder, Resource, System, run_now};
 
 pub use entity::{Component, Entity, Entities};
-=======
-pub use storage::{Storage, UnprotectedStorage, AntiStorage,
-                  VecStorage, HashMapStorage, NullStorage, InsertResult,
-                  MaskedStorage, TrackedStorage};
-pub use world::{Component, World, EntityBuilder, Entities, CreateEntities,
-                Allocator};
->>>>>>> 700efc8... Join implementations for TrackedStorage, some documentation
 pub use join::{Join, JoinIter};
 pub use world::World;
 pub use storage::{CheckStorage, InsertResult, UnprotectedStorage};
@@ -210,7 +202,7 @@ pub mod prelude {
 
     pub use data::{Entities, Fetch, FetchMut, ReadStorage, WriteStorage};
     pub use join::Join;
-    pub use storages::{DenseVecStorage, HashMapStorage, VecStorage};
+    pub use storages::{DenseVecStorage, HashMapStorage, VecStorage, TrackedStorage};
 }
 
 pub use storage::storages;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -151,6 +151,12 @@ impl<'a, 'e, T, D> EntityIndex for Entry<'a, 'e, T, D> {
     }
 }
 
+impl<'a, 'b, 'e, T, D> EntityIndex for &'b Entry<'a, 'e, T, D> {
+    fn index(&self) -> Index {
+        (*self).index()
+    }
+}
+
 /// A storage type that iterates entities that have
 /// a particular component type, but does not return the
 /// component.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,7 +9,7 @@ use mopa::Any;
 use shred::{Fetch, FetchMut, ResourceId, Resources, SystemData};
 
 use join::Join;
-use world::{Component, Entity, Entities};
+use world::{Component, Entity, EntityIndex, Entities};
 use Index;
 
 #[cfg(feature="serialize")]
@@ -143,6 +143,12 @@ pub struct Entry<'a, 'e, T, D> {
     // Pointer for comparison when attempting to check against a storage.
     original: *const Storage<'e, T, D>,
     phantom: PhantomData<&'a ()>,
+}
+
+impl<'a, 'e, T, D> EntityIndex for Entry<'a, 'e, T, D> {
+    fn index(&self) -> Index {
+        self.id
+    }
 }
 
 /// A storage type that iterates entities that have

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -194,3 +194,136 @@ impl<T: Default> UnprotectedStorage<T> for NullStorage<T> {
         Default::default()
     }
 }
+
+/// Wrapper storage that stores modifications to components in a bitset.
+///
+/// **Note: Never use `.iter()` on a mutable component storage that uses this.**
+///
+/// #Example Usage:
+/// 
+/// ```rust,ignore
+///# extern crate specs;
+///# use specs::{Planner, World, RunArg, Component, TrackedStorage, VecStorage, System, Join};
+/// 
+/// pub struct Comp(u32);
+/// impl Component for Comp {
+///     // `TrackedStorage` acts as a wrapper around another storage.
+///     // You can put any store inside of here (e.g. HashMapStorage, VecStorage, etc.)
+///     type Storage = TrackedStorage<Comp, VecStorage<Comp>>;
+/// }
+/// 
+/// pub struct CompSystem;
+/// impl System<()> for CompSystem {
+///     fn run(&mut self, arg: RunArg, _: ()) {
+///         let (entities, mut comps) = arg.fetch(|w| {
+///             (w.entities(), w.write::<Comp>()) 
+///         });
+/// 
+///         // Iterates over all components like normal.
+///         for (entity, comp) in (&entities, &comps).iter() {
+///             // ...
+///         }
+/// 
+///         // **Never do this**
+///         // This will flag all components as modified regardless of whether the inner loop
+///         // did modify their data.
+///         for (entity, comp) in (&entities, &mut comps).iter() {
+///             // ...
+///         }
+/// 
+///         // Instead do something like:
+///         for (entity, comp) in (&entities, &comps.check()).iter() {
+///             if true { // check whether you should modify this component or not.
+///                 let mut comp = comps.get_mut(entity);
+///                 // ...
+///             }
+///         }
+/// 
+///         // To iterate over the flagged/modified components:
+///         for (entity, flagged_comp) in (&entities, (&comps).open().1).iter() {
+///             // ...
+///         }
+/// 
+///         // Clears the tracked storage every frame with this system.
+///         (&mut comps).open().1.clear();
+///     }
+/// }
+///# fn main() { }
+/// ```
+pub struct TrackedStorage<C: Component, T: UnprotectedStorage<C>> {
+    mask: BitSet,
+    storage: T,
+    phantom: PhantomData<C>,
+}
+
+impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for TrackedStorage<C, T> {
+    fn new() -> Self {
+        TrackedStorage {
+            mask: BitSet::new(),
+            storage: T::new(),
+            phantom: PhantomData,
+        }
+    }
+    unsafe fn clean<F>(&mut self, has: F) where F: Fn(Index) -> bool {
+        self.mask.clear();
+        self.storage.clean(has);
+    }
+    unsafe fn get(&self, id: Index) -> &C {
+        self.storage.get(id)
+    }
+    unsafe fn get_mut(&mut self, id: Index) -> &mut C {
+        // calling `.iter()` on a mutable reference to the storage will flag everything
+        self.mask.add(id);
+        self.storage.get_mut(id)
+    }
+    unsafe fn insert(&mut self, id: Index, comp: C) {
+        self.mask.add(id);
+        self.storage.insert(id, comp);
+    }
+    unsafe fn remove(&mut self, id: Index) -> C {
+        self.mask.remove(id);
+        self.storage.remove(id)
+    }
+}
+
+impl<C: Component, T: UnprotectedStorage<C>> TrackedStorage<C, T> {
+    /// All components will be cleared of being flagged.
+    pub fn clear(&mut self) {
+        self.mask.clear();
+    }
+    /// Flags a single component as not flagged.
+    pub fn unflag(&mut self, entity: Entity) {
+        self.mask.remove(entity.get_id());
+    }
+    /// Flags a single component as flagged.
+    pub fn flag(&mut self, entity: Entity) {
+        self.mask.add(entity.get_id());
+    }
+}
+
+impl<'a, C: Component, T: UnprotectedStorage<C>> Join for &'a TrackedStorage<C, T> {
+    type Type = &'a C;
+    type Value = &'a T;
+    type Mask = &'a BitSet;
+    fn open(self) -> (Self::Mask, Self::Value) {
+        (&self.mask, &self.storage)
+    }
+    unsafe fn get(v: &mut Self::Value, id: Index) -> &'a C {
+        v.get(id)
+    }
+}
+
+impl<'a, C: Component, T: UnprotectedStorage<C>> Join for &'a mut TrackedStorage<C, T> {
+    type Type = &'a mut C;
+    type Value = &'a mut T;
+    type Mask = &'a BitSet;
+    fn open(self) -> (Self::Mask, Self::Value) {
+        (&self.mask, &mut self.storage)
+    }
+    unsafe fn get(v: &mut Self::Value, id: Index) -> &'a mut C {
+        // similar issue here as the `Storage<T, A, D>` implementation
+        use std::mem;
+        let value: &'a mut Self::Value = mem::transmute(v);
+        value.get_mut(id)
+    }
+}

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -210,9 +210,9 @@ impl<T: Default> UnprotectedStorage<T> for NullStorage<T> {
 /// 
 /// pub struct Comp(u32);
 /// impl Component for Comp {
-///     // `TrackedStorage` acts as a wrapper around another storage.
+///     // `FlaggedStorage` acts as a wrapper around another storage.
 ///     // You can put any store inside of here (e.g. HashMapStorage, VecStorage, etc.)
-///     type Storage = TrackedStorage<Comp, VecStorage<Comp>>;
+///     type Storage = FlaggedStorage<Comp, VecStorage<Comp>>;
 /// }
 /// 
 /// pub struct CompSystem;
@@ -243,22 +243,22 @@ impl<T: Default> UnprotectedStorage<T> for NullStorage<T> {
 ///         for flagged_comp in ((&comps).open().1).join() {
 ///             // ...
 ///         }
-/// 
+///
 ///         // Clears the tracked storage every frame with this system.
 ///         (&mut comps).open().1.clear_flags();
 ///     }
 /// }
 ///# fn main() { }
 /// ```
-pub struct TrackedStorage<C, T> {
+pub struct FlaggedStorage<C, T> {
     mask: BitSet,
     storage: T,
     phantom: PhantomData<C>,
 }
 
-impl<C, T: UnprotectedStorage<C>> UnprotectedStorage<C> for TrackedStorage<C, T> {
+impl<C, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedStorage<C, T> {
     fn new() -> Self {
-        TrackedStorage {
+        FlaggedStorage {
             mask: BitSet::new(),
             storage: T::new(),
             phantom: PhantomData,
@@ -286,7 +286,7 @@ impl<C, T: UnprotectedStorage<C>> UnprotectedStorage<C> for TrackedStorage<C, T>
     }
 }
 
-impl<C, T: UnprotectedStorage<C>> TrackedStorage<C, T> {
+impl<C, T: UnprotectedStorage<C>> FlaggedStorage<C, T> {
     /// Whether the component related to the entity was flagged or not.
     pub fn flagged<E: EntityIndex>(&self, entity: E) -> bool {
         self.mask.contains(entity.index())
@@ -305,7 +305,7 @@ impl<C, T: UnprotectedStorage<C>> TrackedStorage<C, T> {
     }
 }
 
-impl<'a, C, T: UnprotectedStorage<C>> Join for &'a TrackedStorage<C, T> {
+impl<'a, C, T: UnprotectedStorage<C>> Join for &'a FlaggedStorage<C, T> {
     type Type = &'a C;
     type Value = &'a T;
     type Mask = &'a BitSet;
@@ -317,7 +317,7 @@ impl<'a, C, T: UnprotectedStorage<C>> Join for &'a TrackedStorage<C, T> {
     }
 }
 
-impl<'a, C, T: UnprotectedStorage<C>> Join for &'a mut TrackedStorage<C, T> {
+impl<'a, C, T: UnprotectedStorage<C>> Join for &'a mut FlaggedStorage<C, T> {
     type Type = &'a mut C;
     type Value = &'a mut T;
     type Mask = &'a BitSet;
@@ -331,3 +331,4 @@ impl<'a, C, T: UnprotectedStorage<C>> Join for &'a mut TrackedStorage<C, T> {
         value.get_mut(id)
     }
 }
+

--- a/src/world.rs
+++ b/src/world.rs
@@ -168,6 +168,19 @@ impl<'a> Iterator for CreateIterAtomic<'a> {
     }
 }
 
+/// Any type that contains an entity's index.
+///
+/// e.g. Entry, Entity, etc.
+pub trait EntityIndex {
+    fn index(&self) -> Index;
+}
+
+impl EntityIndex for Entity {
+    fn index(&self) -> Index {
+        self.id()
+    }
+}
+
 /// `Entity` type, as seen by the user.
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Entity(Index, Generation);

--- a/src/world.rs
+++ b/src/world.rs
@@ -181,6 +181,12 @@ impl EntityIndex for Entity {
     }
 }
 
+impl<'a> EntityIndex for &'a Entity {
+    fn index(&self) -> Index {
+        (*self).index()
+    }
+}
+
 /// `Entity` type, as seen by the user.
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Entity(Index, Generation);


### PR DESCRIPTION
A basic implementation for a `TrackedStorage` (https://github.com/slide-rs/specs/issues/89).

This version of the `TrackedStorage` does not implement a way to compare the past version and the modifies version of the components. Usage requires unwrapping the storage to the base `TrackedStorage` which implements `Join` for flagged components.

### Alternative design choices:
**Implement `TrackedStorage` similar to how `MaskedStorage` works.**

_Pros:_
- Would make it possible to have the `Join` of the storage only work on the flagged components without calling any additional methods.
- Might open up a path for a generic storage wrapper like `UnprotectedStorage` but instead as a container for how the `Join` gets the components necessary for the loop (this could be interesting since it would allow for different methods other than bitsets, but would also be pretty hard to get right).

_Cons:_
- Difficult to get all the components instead of just the flagged ones as there is no current way to directly get access to the container storage.
- Might be unintuitive at a glance as you would expect to get all the components when joining the storage.

**Compare modifications for more accurate flags**

_Pros:_
- Removes a large concern for if the user iterates over a mutable tracked storage.

_Cons:_
- Performance benefits of the tracked storage decreases.
- Difficult to implement. Requires a way to directly compare the new "modified" version with the past version.