### PR TITLE
Add World::register_*_maybe (#96)

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -299,3 +299,25 @@ fn dynamic_component() {
     let c = w.read_w_comp_id::<CompBool>(2).get(e).unwrap().0;
     assert_eq!(c, true);
 }
+
+#[test]
+fn register_maybe() {
+    // Test that using `register_maybe` correctly reports
+    // that a component type was already registered rather
+    // than trying to re-register it.
+    let mut w = specs::World::new();
+
+    assert_eq!(w.register_maybe::<CompInt>(), true);
+
+    let e = w.create_now()
+        .with::<CompInt>(CompInt(10))
+        .build();
+
+    // A call to `register` would blindly plough ahead
+    // and create duplicate storage, so...
+    assert_eq!(w.register_maybe::<CompInt>(), false);
+
+    // ...this would end up trying to unwrap a `None`.
+    let i = w.read::<CompInt>().get(e).unwrap().0;
+    assert_eq!(i, 10);
+}


### PR DESCRIPTION
Added `World::{ register_w_comp_id_maybe, register_maybe }` functions.

The implementation of `register_w_comp_id_maybe` doesn't just
call through to `register_w_comp_id` because I'd need to be able
to clone `comp_id`, which isn't possible without requiring the
component ID type to implement `Clone`.

My feeling is that this small redundancy in implementation is worthwhile
to avoid placing additional bounds on the component ID type.