### PR TITLE
Add a PlannerBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,11 @@ exclude = ["doc", ".travis.yml"]
 mopa = "0.2"
 pulse = { version = "0.5", optional = true }
 threadpool = { version = "1.3", optional = true }
+num_cpus = { version = "1.0", optional = true }
 fnv = "1.0"
 tuple_utils="0.2"
 atom = "0.3"
 
 [features]
 default = ["parallel"]
-parallel = ["threadpool", "pulse"]
+parallel = ["threadpool", "pulse", "num_cpus"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ extern crate mopa;
 extern crate pulse;
 #[cfg(feature="parallel")]
 extern crate threadpool;
+#[cfg(feature="parallel")]
+extern crate num_cpus;
 extern crate fnv;
 extern crate tuple_utils;
 extern crate atom;

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -215,6 +215,8 @@ pub struct Planner<C> {
 
 impl<C: 'static> Planner<C> {
     /// Creates a new planner, given the world and the thread count.
+    ///
+    /// For a more flexible creation, see the `PlannerBuilder`.
     pub fn new(world: World, num_threads: usize) -> Planner<C> {
         PlannerBuilder::new()
             .with_world(world)


### PR DESCRIPTION
This allows sharing the thread pool, which is pretty important for highly parallel applications in order to allow a good performance.

Sorry I've done so bad in my previous PR, I hope this one is better.