### PR TITLE
Rename funcs according to #87

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -42,9 +42,9 @@ mod world {
     }
 
     #[bench]
-    fn create_later(b: &mut test::Bencher) {
+    fn create_pure(b: &mut test::Bencher) {
         let w = specs::World::new();
-        b.iter(|| w.create_later());
+        b.iter(|| w.create_pure());
     }
 
     #[bench]
@@ -80,7 +80,7 @@ mod world {
     fn maintain_add_later(b: &mut test::Bencher) {
         let w = specs::World::new();
         b.iter(|| {
-            w.create_later();
+            w.create_pure();
             w.maintain();
         });
     }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -42,7 +42,7 @@ impl RunArg {
     }
     /// Creates a new entity dynamically.
     pub fn create(&self) -> Entity {
-        self.world.create_later()
+        self.world.create_pure()
     }
     /// Deletes an entity dynamically.
     pub fn delete(&self, entity: Entity) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -317,13 +317,13 @@ impl<C> World<C>
         }
     }
     /// Creates a new entity dynamically.
-    pub fn create_later(&self) -> Entity {
+    pub fn create_pure(&self) -> Entity {
         let allocator = self.allocator.read().unwrap();
         allocator.allocate_atomic()
     }
     /// Creates a new entity dynamically, and starts building it.
-    pub fn create_later_build(&self) -> EntityBuilder<C> {
-        EntityBuilder::new(self.create_later(), self)
+    pub fn create(&self) -> EntityBuilder<C> {
+        EntityBuilder::new(self.create_pure(), self)
     }
     /// Deletes an entity dynamically.
     pub fn delete_later(&self, entity: Entity) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -164,16 +164,16 @@ fn mixed_create_merge() {
 
     let insert = |planner: &mut specs::Planner<()>, set: &mut HashSet<Entity>, cnt: usize| {
         // Check to make sure there is no conflict between create_now
-        // and create_later
+        // and create_pure
         for _ in 0..10 {
             for _ in 0..cnt {
                 let mut w = planner.mut_world();
                 add(set, w.create_now().build());
                 let e = w.create_now().build();
                 w.delete_now(e);
-                add(set, w.create_later());
+                add(set, w.create_pure());
                 //  swap order
-                add(set, w.create_later());
+                add(set, w.create_pure());
                 add(set, w.create_now().build());
             }
             planner.wait();


### PR DESCRIPTION
- rename `create_later_build` to `create`, assuming it's what users actually want to use
- rename `create_later` to `create_pure`, reflecting the fact only the Entity is created with no building.