### PR TITLE
Rename funcs according to #87

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -42,9 +42,9 @@ mod world {
     }
 
     #[bench]
-    fn create_later(b: &mut test::Bencher) {
+    fn create_pure(b: &mut test::Bencher) {
         let w = specs::World::new();
-        b.iter(|| w.create_later());
+        b.iter(|| w.create_pure());
     }
 
     #[bench]
@@ -80,7 +80,7 @@ mod world {
     fn maintain_add_later(b: &mut test::Bencher) {
         let w = specs::World::new();
         b.iter(|| {
-            w.create_later();
+            w.create_pure();
             w.maintain();
         });
     }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -86,9 +86,9 @@ fn main() {
         }
 
         // Dynamically creating and deleting entities
-        let e0 = arg.create();
+        let e0 = arg.create_pure();
         sa.insert(e0, CompInt(-4));
-        let e1 = arg.create();
+        let e1 = arg.create_pure();
         sa.insert(e1, CompInt(-5));
         arg.delete(e0);
     });

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -41,8 +41,8 @@ impl RunArg {
         (entities, self.fetch(f))
     }
     /// Creates a new entity dynamically.
-    pub fn create(&self) -> Entity {
-        self.world.create_later()
+    pub fn create_pure(&self) -> Entity {
+        self.world.create_pure()
     }
     /// Deletes an entity dynamically.
     pub fn delete(&self, entity: Entity) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -317,13 +317,13 @@ impl<C> World<C>
         }
     }
     /// Creates a new entity dynamically.
-    pub fn create_later(&self) -> Entity {
+    pub fn create_pure(&self) -> Entity {
         let allocator = self.allocator.read().unwrap();
         allocator.allocate_atomic()
     }
     /// Creates a new entity dynamically, and starts building it.
-    pub fn create_later_build(&self) -> EntityBuilder<C> {
-        EntityBuilder::new(self.create_later(), self)
+    pub fn create(&self) -> EntityBuilder<C> {
+        EntityBuilder::new(self.create_pure(), self)
     }
     /// Deletes an entity dynamically.
     pub fn delete_later(&self, entity: Entity) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -97,7 +97,7 @@ fn dynamic_create() {
     for _ in 0..1_000 {
         planner.run_custom(|arg| {
             arg.fetch(|_| ());
-            arg.create();
+            arg.create_pure();
         });
         planner.wait();
     }
@@ -111,7 +111,7 @@ fn dynamic_deletion() {
     for _ in 0..1_000 {
         planner.run_custom(|arg| {
             arg.fetch(|_| ());
-            let e = arg.create();
+            let e = arg.create_pure();
             arg.delete(e);
             arg.delete(e); // double free
         });
@@ -135,7 +135,7 @@ fn dynamic_create_and_delete() {
         planner.run_custom(move |arg| {
             arg.fetch(|_| ());
             let mut e = e.lock().unwrap();
-            *e = Some(arg.create());
+            *e = Some(arg.create_pure());
         });
         if i >= 1 {
             let e = ent1.clone();
@@ -164,16 +164,16 @@ fn mixed_create_merge() {
 
     let insert = |planner: &mut specs::Planner<()>, set: &mut HashSet<Entity>, cnt: usize| {
         // Check to make sure there is no conflict between create_now
-        // and create_later
+        // and create_pure
         for _ in 0..10 {
             for _ in 0..cnt {
                 let mut w = planner.mut_world();
                 add(set, w.create_now().build());
                 let e = w.create_now().build();
                 w.delete_now(e);
-                add(set, w.create_later());
+                add(set, w.create_pure());
                 //  swap order
-                add(set, w.create_later());
+                add(set, w.create_pure());
                 add(set, w.create_now().build());
             }
             planner.wait();
@@ -268,7 +268,7 @@ fn stillborn_entities() {
             for &i in values.iter() {
                 use specs::InsertResult::EntityIsDead;
 
-                let result = compint.insert(arg.create(), CompInt(i));
+                let result = compint.insert(arg.create_pure(), CompInt(i));
                 if let EntityIsDead(_) = result {
                     panic!("Couldn't insert {} into a stillborn entity", i);
                 }


### PR DESCRIPTION
- rename `create_later_build` to `create`, assuming it's what users actually want to use
- rename `create_later` to `create_pure`, reflecting the fact only the Entity is created with no building.
Also rename `RunArg::create` to `RunArg::create_pure` for the same reason.