### PR TITLE
Made benchmarks runnable

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -31,13 +31,13 @@ mod world {
 
     #[bench]
     fn create_now(b: &mut test::Bencher) {
-        let w = specs::World::new();
+        let mut w = specs::World::new();
         b.iter(|| w.create_now().build());
     }
 
     #[bench]
     fn create_now_with_storage(b: &mut test::Bencher) {
-        let w = create_world();
+        let mut w = create_world();
         b.iter(|| w.create_now().with(CompInt(0)).build());
     }
 
@@ -49,28 +49,28 @@ mod world {
 
     #[bench]
     fn delete_now(b: &mut test::Bencher) {
-        let w = specs::World::new();
+        let mut w = specs::World::new();
         let mut eids: Vec<_> = (0..1_000_000).map(|_| w.create_now().build()).collect();
         b.iter(|| w.delete_now(eids.pop().unwrap()));
     }
 
     #[bench]
     fn delete_now_with_storage(b: &mut test::Bencher) {
-        let w = create_world();
+        let mut w = create_world();
         let mut eids: Vec<_> = (0..1_000_000).map(|_| w.create_now().with(CompInt(1)).build()).collect();
         b.iter(|| w.delete_now(eids.pop().unwrap()));
     }
 
     #[bench]
     fn delete_later(b: &mut test::Bencher) {
-        let w = specs::World::new();
+        let mut w = specs::World::new();
         let mut eids: Vec<_> = (0..1_000_000).map(|_| w.create_now().build()).collect();
         b.iter(|| w.delete_later(eids.pop().unwrap()));
     }
 
     #[bench]
     fn maintain_noop(b: &mut test::Bencher) {
-        let w = specs::World::new();
+        let mut w = specs::World::new();
         b.iter(|| {
             w.maintain();
         });
@@ -78,7 +78,7 @@ mod world {
 
     #[bench]
     fn maintain_add_later(b: &mut test::Bencher) {
-        let w = specs::World::new();
+        let mut w = specs::World::new();
         b.iter(|| {
             w.create_pure();
             w.maintain();
@@ -87,7 +87,7 @@ mod world {
 
     #[bench]
     fn maintain_delete_later(b: &mut test::Bencher) {
-        let w = specs::World::new();
+        let mut w = specs::World::new();
         let mut eids: Vec<_> = (0..1_000_000).map(|_| w.create_now().build()).collect();
         b.iter(|| {
             w.delete_later(eids.pop().unwrap());
@@ -98,7 +98,7 @@ mod world {
 
 mod bitset {
     use test;
-    use specs::BitSet;
+    use specs::bitset::BitSet;
 
     #[bench]
     fn add(b: &mut test::Bencher) {
@@ -139,7 +139,7 @@ mod bitset {
 
 mod atomic_bitset {
     use test;
-    use specs::AtomicBitSet;
+    use specs::bitset::AtomicBitSet;
 
     #[bench]
     fn add(b: &mut test::Bencher) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@ pub use planner::*; // * because planner contains many macro-generated public fu
 
 mod storage;
 mod world;
-mod bitset;
+#[doc(hidden)]
+pub mod bitset;
 mod gate;
 mod join;
 #[cfg(feature="parallel")]


### PR DESCRIPTION
I tried to run benchmarks and noticed that they don't work:
* bitsets were moved to different place, were private and didn't have documentations
* There were mutability problems with bunch of benchmarks.

After fixing these, benchmarks work, but `create_now` test panics:
````
test world::create_now              ... thread 'main' panicked at 'index out of bounds: the len is 1024 but the index is 1024', src\libcollections\vec.rs:1401
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: specs::world::Allocator::allocate
   1: <specs::world::World<C>>::create_now
   2: benches::world::create_now
   3: test::run_test
   4: test::run_tests
   5: test::run_tests_console
   6: test::test_main
   7: test::test_main_static
   8: benches::__test::main
   9: std::panicking::try::do_call
  10: __rust_maybe_catch_panic
  11: std::rt::lang_start
  12: main
  13: __tmainCRTStartup
  14: unit_addrs_search
  15: unit_addrs_search
````