### PR TITLE
[WIP] ExternalSystem type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use storage::{AntiStorage, BTreeStorage, GatedStorage, HashMapStorage, Inser
 pub use world::{Allocator, Component, CreateEntities, Entities, World};
 
 #[cfg(feature="parallel")]
-pub use planner::{Planner, Priority, RunArg, System, SystemInfo};
+pub use planner::{Planner, Priority, RunArg, System, SystemInfo, ExternalSystem};
 
 
 #[doc(hidden)]


### PR DESCRIPTION
The implementation is not correct yet, and this is a little bigger problem than just this PR. It's about `RunArg` getting sent while the system guard considers it done. We need to:
  1. prevent sending of `RunArg` or storing it. Perhaps, `run` should return it?
  2. make the system guard also wait for the external system, somehow