### PR TITLE
Reexport MergeError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use world::{Allocator, Component, CreateEntities, Entities, World};
 pub use planner::{Planner, Priority, RunArg, System, SystemInfo};
 
 #[cfg(feature="serialize")]
-pub use storage::PackedData;
+pub use storage::{MergeError, PackedData};
 
 #[doc(hidden)]
 pub mod bitset;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -223,7 +223,14 @@ impl<T, A, D> Storage<T, A, D>
     }
 }
 
+/// The error type returned
+/// by [`Storage::merge`].
+///
+/// [`Storage::merge`]: struct.Storage.html#method.merge
+#[cfg(feature="serialize")]
 pub enum MergeError {
+    /// Returned if there is no
+    /// entity matching the specified offset.
     NoEntity(Index),
 }
 


### PR DESCRIPTION
It was not exported even though it's part of the public API (I though there was an error for this).

* Add documentation
* Add cfg attribute