### PR TITLE
Remove bounds from world struct and entity builder

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -92,14 +92,13 @@ pub struct Entry<'a, T, A, D> {
 /// A storage type that iterates entities that have
 /// a particular component type, but does not return the
 /// component.
-pub struct CheckStorage<T: Component, A, D> {
+pub struct CheckStorage<T, A, D> {
     bitset: BitSet,
     // Pointer back to the storage the CheckStorage was created from.
     original: *const Storage<T, A, D>,
 }
 
-impl<'a, T, A, D> Join for &'a CheckStorage<T, A, D>
-    where T: Component {
+impl<'a, T, A, D> Join for &'a CheckStorage<T, A, D> {
     type Type = Entry<'a, T, A, D>;
     type Value = *const Storage<T, A, D>;
     type Mask = &'a BitSet;

--- a/src/world.rs
+++ b/src/world.rs
@@ -106,7 +106,7 @@ impl<'a> Gate for Entities<'a> {
 }
 
 /// Helper builder for entities.
-pub struct EntityBuilder<'a, C = ()>(Entity, &'a World<C>) where C: 'a + PartialEq + Eq + Hash;
+pub struct EntityBuilder<'a, C = ()>(Entity, &'a World<C>) where C: 'a;
 
 impl<'a, C> EntityBuilder<'a, C>
     where C: 'a + PartialEq + Eq + Hash
@@ -298,9 +298,7 @@ impl<T: Any + Send + Sync> ResourceLock for Lock<T> {}
 /// The `World` struct contains all the data, which is entities and their components.
 /// All methods are supposed to be valid for any context they are available in.
 /// The type parameter C is for component identification in addition of their types.
-pub struct World<C = ()>
-    where C: PartialEq + Eq + Hash
-{
+pub struct World<C = ()> {
     allocator: RwLock<Allocator>,
     components: HashMap<(C, TypeId), Box<StorageLock>, BuildHasherDefault<FnvHasher>>,
     resources: HashMap<TypeId, Box<ResourceLock>, BuildHasherDefault<FnvHasher>>,


### PR DESCRIPTION
Removes bounds on the struct, but leaving them in the implementations removes a lot of boilerplate when using the `World`. Since not all methods related to the `World` require those bounds.