### PR TITLE
Add SmallVec storage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hibitset = "0.1"
 mopa = "0.2"
 ticketed_lock = "0.1"
 tuple_utils = "0.2"
+smallvec = "0.4"
 
 pulse = { version = "0.5", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate hibitset;
 extern crate mopa;
 extern crate ticketed_lock;
 extern crate tuple_utils;
+extern crate smallvec;
 
 #[cfg(feature="parallel")]
 extern crate pulse;
@@ -29,7 +30,7 @@ pub use gate::Gate;
 pub use join::{Join, JoinIter};
 pub use storage::{AntiStorage, BTreeStorage, GatedStorage, HashMapStorage, InsertResult,
                   MaskedStorage, NullStorage, Storage, UnprotectedStorage, VecStorage,
-                  DenseVecStorage};
+                  DenseVecStorage, SmallVecStorage};
 pub use world::{Allocator, Component, CreateEntities, Entities, World};
 
 #[cfg(feature="parallel")]


### PR DESCRIPTION
SmallVec storage from [smallvec](https://github.com/servo/rust-smallvec) crate, for optimized storage of small number of components.
Should it be behind feature flag, since in brings new dependency?