### PR TITLE
Use published hibitset and lock shred dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ exclude = ["doc", ".travis.yml"]
 [dependencies]
 atom = "0.3"
 fnv = "1.0"
-hibitset = { git = "https://github.com/slide-rs/hibitset" }
+hibitset = "0.1.1"
 mopa = "0.2"
-shred = { git = "https://github.com/torkleyy/shred" }
+shred = { git = "https://github.com/torkleyy/shred", rev = "9651382c08d3023db7787a2df751f41403190f71" }
 shred-derive = "0.1.2"
 tuple_utils = "0.2"
 


### PR DESCRIPTION
This temporarily locks the shred dependency on the current commit, so it does not break as soon as I merge anything into shred master.