### PR TITLE
Better document that World::maintain is necessary after using `Entities`

### DIFF
--- a/book/src/06_system_data.md
+++ b/book/src/06_system_data.md
@@ -14,6 +14,10 @@ good news for you. You can just use `specs::data::Entities`
 Please note that you may never write to these `Entities`, so only
 use `Fetch`. Even though it's immutable, you can atomically create
 and delete entities with it. Just use the `.create()` and `.delete()`
-methods, respectively. You cannot, however, easily build an entity
+methods, respectively. After dynamic entity creation / deletion,
+a call `World::maintain` is necessary in order to make the changes
+persistent and delete associated components.
+
+You cannot, however, easily build an entity
 with associated components. For that, you have to write these component
 storages and insert a component for your entity.

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -204,9 +204,11 @@ fn main() {
         .build();
 
     dispatcher.dispatch(&mut w.res);
+    w.maintain();
 
     // Insert a component, associated with `e`.
     w.write().insert(e, CompFloat(4.0));
 
     dispatcher.dispatch(&mut w.res);
+    w.maintain();
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -111,6 +111,7 @@ fn main() {
         .build();
 
     dispatcher.dispatch(&mut world.res);
+    world.maintain();
 }
 
 #[cfg(not(feature="serialize"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ pub mod data {
     /// ```ignore
     /// type SystemData = (Entities<'a>, ...);
     /// ```
+    ///
+    /// Please note that you should call `World::maintain`
+    /// after creating / deleting entities with this resource.
     pub type Entities<'a> = Fetch<'a, ::entity::Entities>;
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -228,6 +228,9 @@ impl<'a> EntityBuilder<'a> {
 /// **Please note that you should never fetch
 /// this mutably in a system, because it would
 /// block all the other systems.**
+///
+/// You need to call `World::maintain` after creating / deleting
+/// entities with this struct.
 #[derive(Debug, Default)]
 pub struct Entities {
     alloc: Allocator,


### PR DESCRIPTION
I wonder if we should just always call `world.maintain()` in the examples.