### PR TITLE
Update to shred 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ atom = "0.3"
 fnv = "1.0"
 hibitset = "0.1.2"
 mopa = "0.2"
-shred = { git = "https://github.com/slide-rs/shred", rev = "a50fe15104cd4b21d094f5aaade41795e7a897ea" }
-shred-derive = "0.2"
+shred = "0.4"
+shred-derive = "0.3"
 tuple_utils = "0.2"
 
 serde = { version = "1.0", optional = true }

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -262,6 +262,10 @@ impl<'a> System<'a> for GenCollisions {
     fn run(&mut self, _: Self::SystemData) {
         // TODO
     }
+
+    fn running_time(&self) -> RunningTime {
+        RunningTime::VeryShort
+    }
 }
 
 #[bench]

--- a/book/src/02_hello_world.md
+++ b/book/src/02_hello_world.md
@@ -119,13 +119,13 @@ impl<'a> System<'a> for HelloWorld {
 ## Running the system
 
 This just iterates through all the components and prints
-them. To execute the system, you can use `run_now` like this:
+them. To execute the system, you can use `RunNow` like this:
 
 ```rust,ignore
-use specs::run_now;
+use specs::RunNow;
 
 let hello_world = HelloWorld;
-run_now(hello_world, &mut world.res);
+hello_world.run_now(&world.res);
 ```
 
 ## Full example code
@@ -176,7 +176,7 @@ fn main() {
     world.create_entity().with(Position { x: 4.0, y: 7.0 }).build();
     
     let hello_world = HelloWorld;
-    run_now(hello_world, &mut world.res);
+    hell_world.run_now(&world.res);
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-pub use shred::{AsyncDispatcher, Dispatcher, DispatcherBuilder, Resource, System, run_now};
+pub use shred::{AsyncDispatcher, Dispatcher, DispatcherBuilder, Resource, RunNow, RunningTime,
+                System};
 
 pub use entity::{Component, Entity, Entities};
 pub use join::{Join, JoinIter};
@@ -198,7 +199,8 @@ pub mod entity {
 
 /// Reexports for very common types.
 pub mod prelude {
-    pub use {Component, Dispatcher, DispatcherBuilder, Entity, Resource, System, World};
+    pub use {Component, Dispatcher, DispatcherBuilder, Entity, Resource, RunningTime, System,
+             World};
 
     pub use data::{Entities, Fetch, FetchMut, ReadStorage, WriteStorage};
     pub use join::Join;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,12 +30,12 @@ impl<'a, T> SystemData<'a> for ReadStorage<'a, T>
         Storage::new(res.fetch(0), res.fetch(id))
     }
 
-    unsafe fn reads(id: usize) -> Vec<ResourceId> {
+    fn reads(id: usize) -> Vec<ResourceId> {
         vec![ResourceId::new::<Entities>(),
              ResourceId::new_with_id::<MaskedStorage<T>>(id)]
     }
 
-    unsafe fn writes(_: usize) -> Vec<ResourceId> {
+    fn writes(_: usize) -> Vec<ResourceId> {
         vec![]
     }
 }
@@ -50,11 +50,11 @@ impl<'a, T> SystemData<'a> for WriteStorage<'a, T>
         Storage::new(res.fetch(0), res.fetch_mut(id))
     }
 
-    unsafe fn reads(_: usize) -> Vec<ResourceId> {
+    fn reads(_: usize) -> Vec<ResourceId> {
         vec![ResourceId::new::<Entities>()]
     }
 
-    unsafe fn writes(id: usize) -> Vec<ResourceId> {
+    fn writes(id: usize) -> Vec<ResourceId> {
         vec![ResourceId::new_with_id::<MaskedStorage<T>>(id)]
     }
 }


### PR DESCRIPTION
Now specs can make use of [a major optimization](https://github.com/slide-rs/shred/pull/33) in `shred` and [a bugfix](https://github.com/slide-rs/shred/issues/35) in `shred-derive`.

Also improves bench by specifying running time.