### PR TITLE
Remove `Split` bound from parallel iterator impl

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -137,7 +137,7 @@ impl<J> ParallelIterator for JoinParIter<J>
   where
     J: Join + Send,
     J::Type: Send,
-    J::Value: Split + Send,
+    J::Value: Send,
     J::Mask: Send + Sync,
 {
     type Item = J::Type;


### PR DESCRIPTION
This allows to iterate over a single component storage in parallel.

r? @WaDelma 