### PR TITLE
Add parallel joins to several places

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -33,6 +33,7 @@ impl<'a> System<'a> for SysA {
 
         let (mut pos, vel) = data;
 
+        // You could also use `par_join()` to get a rayon `ParallelIterator`.
         for (pos, vel) in (&mut pos, &vel).join() {
             pos.0 += vel.0;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,10 @@
 //!
 //!         let (mut pos, vel) = data;
 //!
+//!         // This joins the component storages for Position
+//!         // and Velocity together; it's also possible to do this
+//!         // in parallel using rayon's `ParallelIterator`s.
+//!         // See `ParJoin` for more.
 //!         for (pos, vel) in (&mut pos, &vel).join() {
 //!             pos.0 += vel.0;
 //!         }
@@ -142,7 +146,7 @@ pub use shred::{AsyncDispatcher, Dispatcher, DispatcherBuilder, Resource, RunNow
                 System};
 
 pub use entity::{Component, Entity, Entities};
-pub use join::{Join, JoinIter};
+pub use join::{Join, JoinIter, JoinParIter, ParJoin};
 pub use world::World;
 pub use storage::{CheckStorage, InsertResult, UnprotectedStorage};
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -284,7 +284,7 @@ impl<'e, T, D> Storage<'e, T, D>
     }
 }
 
-/// The status of an `insert()`ion into a storage operation.
+/// The status of an `insert()`ion into a storage.
 #[derive(Debug)]
 pub enum InsertResult<T> {
     /// The value was inserted and there was no value before

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -447,6 +447,8 @@ fn par_join_many_entities_and_systems() {
         .build();
     dispatcher.dispatch(&mut world.res);
     for &(id, n) in &*failed.lock().unwrap() {
-        panic!("Entity with id {} failed to count to 127. Count was {}", id, n);
+        panic!("Entity with id {} failed to count to 127. Count was {}",
+               id,
+               n);
     }
 }


### PR DESCRIPTION
* Note in basic example and crate root
* Reexport in crate root
* Add benchmark for them

```
test world::join_multi_threaded     ... bench:      77,374 ns/iter (+/- 20,560)
test world::join_single_threaded    ... bench:     233,356 ns/iter (+/- 2,279)
```

:tada: 