### PR TITLE
Restructure type reexports

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+reorder_imported_names = true

--- a/README.md
+++ b/README.md
@@ -33,13 +33,8 @@ Unlike most other ECS libraries out there, it provides
 ## Example
 
 ```rust
-extern crate specs;
-
-use specs::prelude::*;
-
 // A component contains data
 // which is associated with an entity.
-
 #[derive(Debug)]
 struct Vel(f32);
 #[derive(Debug)]
@@ -78,7 +73,6 @@ fn main() {
     // The `World` is our
     // container for components
     // and other resources.
-
     let mut world = World::new();
     world.register::<Pos>();
     world.register::<Vel>();

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -8,8 +8,9 @@ extern crate test;
 
 use cgmath::Vector2;
 use rand::thread_rng;
-use specs::prelude::*;
-use specs::storages::NullStorage;
+use specs::{Component, DenseVecStorage, DispatcherBuilder, Entities, Entity, Fetch,
+            HashMapStorage, Join, NullStorage, ReadStorage, RunningTime, System, VecStorage,
+            World, WriteStorage};
 
 use test::Bencher;
 

--- a/benches/world.rs
+++ b/benches/world.rs
@@ -7,8 +7,7 @@ extern crate specs;
 
 extern crate test;
 
-use specs::{Component, World};
-use specs::storages::{HashMapStorage, VecStorage};
+use specs::{Component, HashMapStorage, Join, ParJoin, VecStorage, World};
 
 #[derive(Clone, Debug)]
 struct CompInt(i32);
@@ -61,8 +60,8 @@ fn delete_now(b: &mut test::Bencher) {
     let mut w = World::new();
     let mut eids: Vec<_> = (0..10_000_000).map(|_| w.create_entity().build()).collect();
     b.iter(|| if let Some(id) = eids.pop() {
-        w.delete_entity(id)
-    });
+               w.delete_entity(id)
+           });
 }
 
 #[bench]
@@ -72,8 +71,8 @@ fn delete_now_with_storage(b: &mut test::Bencher) {
         .map(|_| w.create_entity().with(CompInt(1)).build())
         .collect();
     b.iter(|| if let Some(id) = eids.pop() {
-        w.delete_entity(id)
-    });
+               w.delete_entity(id)
+           });
 }
 
 #[bench]
@@ -81,8 +80,8 @@ fn delete_later(b: &mut test::Bencher) {
     let mut w = World::new();
     let mut eids: Vec<_> = (0..10_000_000).map(|_| w.create_entity().build()).collect();
     b.iter(|| if let Some(id) = eids.pop() {
-        w.entities().delete(id)
-    });
+               w.entities().delete(id)
+           });
 }
 
 #[bench]
@@ -95,9 +94,9 @@ fn maintain_noop(b: &mut test::Bencher) {
 fn maintain_add_later(b: &mut test::Bencher) {
     let mut w = World::new();
     b.iter(|| {
-        w.entities().create();
-        w.maintain();
-    });
+               w.entities().create();
+               w.maintain();
+           });
 }
 
 #[bench]
@@ -105,16 +104,15 @@ fn maintain_delete_later(b: &mut test::Bencher) {
     let mut w = World::new();
     let mut eids: Vec<_> = (0..10_000_000).map(|_| w.create_entity().build()).collect();
     b.iter(|| {
-        if let Some(id) = eids.pop() {
-            w.entities().delete(id);
-        }
-        w.maintain();
-    });
+               if let Some(id) = eids.pop() {
+                   w.entities().delete(id);
+               }
+               w.maintain();
+           });
 }
 
 #[bench]
 fn join_single_threaded(b: &mut test::Bencher) {
-    use specs::Join;
     use test::black_box;
 
     let mut world = World::new();
@@ -129,14 +127,13 @@ fn join_single_threaded(b: &mut test::Bencher) {
     }
 
     b.iter(|| for comp in world.read::<CompInt>().join() {
-        black_box(comp.0 * comp.0);
-    })
+               black_box(comp.0 * comp.0);
+           })
 }
 
 #[bench]
 fn join_multi_threaded(b: &mut test::Bencher) {
     use rayon::prelude::*;
-    use specs::ParJoin;
     use test::black_box;
 
     let mut world = World::new();
@@ -151,9 +148,9 @@ fn join_multi_threaded(b: &mut test::Bencher) {
     }
 
     b.iter(|| {
-        world
-            .read::<CompInt>()
-            .par_join()
-            .for_each(|comp| { black_box(comp.0 * comp.0); })
-    })
+               world
+                   .read::<CompInt>()
+                   .par_join()
+                   .for_each(|comp| { black_box(comp.0 * comp.0); })
+           })
 }

--- a/book/src/02_hello_world.md
+++ b/book/src/02_hello_world.md
@@ -180,9 +180,6 @@ fn main() {
 }
 ```
 
-> **Note:** You can use `use specs::prelude::*;` to include all
-  the common types.
-
 ---
 
 This was a pretty basic example so far. A key feature we

--- a/book/src/03_dispatcher.md
+++ b/book/src/03_dispatcher.md
@@ -105,9 +105,8 @@ dispatcher.dispatch(&mut world.res);
 Here the code for this chapter:
 
 ```rust,ignore
-// Notice that I changed the import 
-// because it's too much otherwise.
-use specs::prelude::*;
+use specs::{Component, DispatcherBuilder ReadStorage,
+            System, VecStorage, World, WriteStorage};
 
 #[derive(Debug)]
 struct Position { 

--- a/book/src/04_resources.md
+++ b/book/src/04_resources.md
@@ -38,7 +38,7 @@ write access).
 So we can now rewrite our system:
 
 ```rust,ignore
-use specs::prelude::*;
+use specs::{Fetch, ReadStorage, System, WriteStorage};
 
 struct PosUpdate;
 

--- a/book/src/05_storages.md
+++ b/book/src/05_storages.md
@@ -5,7 +5,7 @@ different use cases. But let's see some basics first.
 
 ## Storage basics
 
-What you specify in a system `impl`-block is an `UnprotectedStorage`.
+What you specify in a component `impl`-block is an `UnprotectedStorage`.
 Each `UnprotectedStorage` exposes an unsafe getter which does not
 perform any checks whether the requested index for the component is valid
 (the id of an entity is the index of its component). To allow checking them

--- a/book/src/06_system_data.md
+++ b/book/src/06_system_data.md
@@ -3,12 +3,11 @@
 ## Accessing Entities
 
 You want to create/delete entities from a system? There is
-good news for you. You can just use `specs::data::Entities`
-(which also is in prelude) to do that. It implements
-`SystemData` so just put it 
+good news for you. You can just use `Entities` to do that.
+It implements `SystemData` so just put it in your `SystemData` tuple.
 
-> Don't confuse `specs::data::Entities` with `specs::entity::Entities`.
-  While the latter one is the actual resource, the first one is a type
+> Don't confuse `specs::Entities` with `specs::EntitiesRes`.
+  While the latter one is the actual resource, the other one is a type
   definition for `Fetch<entity::Entities>`.
 
 Please note that you may never write to these `Entities`, so only
@@ -19,7 +18,5 @@ a call `World::maintain` is necessary in order to make the changes
 persistent and delete associated components.
 
 You cannot, however, easily build an entity
-with associated components. For that, you have to write these component
+with associated components. For that, you have to write to these component
 storages and insert a component for your entity.
-
-

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,7 @@
 extern crate specs;
 
-use specs::prelude::*;
+use specs::{Component, DispatcherBuilder, Join, ReadStorage, System, VecStorage, World,
+            WriteStorage};
 
 // A component contains data
 // which is associated with an entity.

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -14,8 +14,8 @@ extern crate serde_json;
 fn main() {
     use serde::Serialize;
     use serde_json::{Serializer, from_str as json_from_str};
-    use specs::prelude::*;
-    use specs::PackedData;
+    use specs::{Component, DispatcherBuilder, Entities, Join, PackedData, System, VecStorage,
+                World, WriteStorage};
 
     #[derive(Debug, Serialize, Deserialize)]
     struct CompSerialize {

--- a/src/join.rs
+++ b/src/join.rs
@@ -2,10 +2,8 @@ use std;
 use std::cell::UnsafeCell;
 
 use hibitset::{BitSetAnd, BitIter, BitSetLike, BitProducer};
-
 use rayon::iter::ParallelIterator;
 use rayon::iter::internal::{Folder, UnindexedConsumer, UnindexedProducer, bridge_unindexed};
-
 use tuple_utils::Split;
 
 use Index;

--- a/src/storage/check.rs
+++ b/src/storage/check.rs
@@ -4,10 +4,9 @@ use std::ops::{Deref, DerefMut};
 
 use hibitset::BitSet;
 
-use join::Join;
-use storage::{DistinctStorage, MaskedStorage, Storage, UnprotectedStorage};
-use world::{Component, EntityIndex};
-use Index;
+use storage::MaskedStorage;
+use world::EntityIndex;
+use {Component, DistinctStorage, Index, Join, Storage, UnprotectedStorage};
 
 /// A storage type that iterates entities that have
 /// a particular component type, but does not return the

--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -1,9 +1,7 @@
-
 use shred::{Fetch, FetchMut, ResourceId, Resources, SystemData};
 
-use world::{Component, Entities};
-
-use storage::{MaskedStorage, Storage};
+use storage::MaskedStorage;
+use {Component, EntitiesRes, Storage};
 
 /// A storage with read access.
 pub type ReadStorage<'a, T> = Storage<'a, T, Fetch<'a, MaskedStorage<T>>>;
@@ -16,7 +14,7 @@ impl<'a, T> SystemData<'a> for ReadStorage<'a, T>
     }
 
     fn reads(id: usize) -> Vec<ResourceId> {
-        vec![ResourceId::new::<Entities>(),
+        vec![ResourceId::new::<EntitiesRes>(),
              ResourceId::new_with_id::<MaskedStorage<T>>(id)]
     }
 
@@ -36,7 +34,7 @@ impl<'a, T> SystemData<'a> for WriteStorage<'a, T>
     }
 
     fn reads(_: usize) -> Vec<ResourceId> {
-        vec![ResourceId::new::<Entities>()]
+        vec![ResourceId::new::<EntitiesRes>()]
     }
 
     fn writes(id: usize) -> Vec<ResourceId> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,8 @@ pub use self::check::{CheckStorage, Entry};
 pub use self::data::{ReadStorage, WriteStorage};
 #[cfg(feature = "serialize")]
 pub use self::ser::{MergeError, PackedData};
+pub use self::storages::{BTreeStorage, DenseVecStorage, FlaggedStorage, HashMapStorage,
+                         NullStorage, VecStorage};
 
 use std;
 use std::marker::PhantomData;
@@ -13,16 +15,13 @@ use hibitset::{BitSet, BitSetNot};
 use mopa::Any;
 use shred::Fetch;
 
-use join::{Join, ParJoin};
-use world::{Component, Entity, Entities};
-use Index;
-
-pub mod storages;
+use {Component, EntitiesRes, Entity, Index, Join, ParJoin};
 
 mod check;
 mod data;
 #[cfg(feature = "serialize")]
 mod ser;
+mod storages;
 #[cfg(test)]
 mod tests;
 
@@ -146,13 +145,13 @@ impl<T: Component> Drop for MaskedStorage<T> {
 /// This is what `World::read/write` fetches for the user.
 pub struct Storage<'e, T, D> {
     data: D,
-    entities: Fetch<'e, Entities>,
+    entities: Fetch<'e, EntitiesRes>,
     phantom: PhantomData<T>,
 }
 
 impl<'e, T, D> Storage<'e, T, D> {
     /// Create a new `Storage`
-    pub fn new(entities: Fetch<'e, Entities>, data: D) -> Storage<'e, T, D> {
+    pub fn new(entities: Fetch<'e, EntitiesRes>, data: D) -> Storage<'e, T, D> {
         Storage {
             data: data,
             entities: entities,

--- a/src/storage/ser.rs
+++ b/src/storage/ser.rs
@@ -1,12 +1,10 @@
-
 use std::ops::{Deref, DerefMut};
 
-use Index;
-use join::Join;
 use serde::{Deserialize, Serialize, Serializer};
 use serde::ser::SerializeStruct;
-use storage::{MaskedStorage, Storage, UnprotectedStorage};
-use world::{Component, Entity};
+
+use storage::MaskedStorage;
+use {Component, Entity, Index, Join, Storage, UnprotectedStorage};
 
 /// The error type returned
 /// by [`Storage::merge`].

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -6,9 +6,8 @@ use std::marker::PhantomData;
 use fnv::FnvHashMap;
 use hibitset::BitSet;
 
-use storage::{UnprotectedStorage, DistinctStorage};
 use world::EntityIndex;
-use {Join, Index};
+use {DistinctStorage, Index, Join, UnprotectedStorage};
 
 /// BTreeMap-based storage.
 pub struct BTreeStorage<T>(BTreeMap<Index, T>);
@@ -53,7 +52,8 @@ unsafe impl<T> DistinctStorage for BTreeStorage<T> {}
 ///
 /// ```rust
 /// extern crate specs;
-/// use specs::prelude::*;
+///
+/// use specs::{Component, FlaggedStorage, Join, System, VecStorage, WriteStorage};
 ///
 /// pub struct Comp(u32);
 /// impl Component for Comp {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,9 +1,7 @@
 use mopa::Any;
 
 use super::*;
-use super::storages::*;
-use entity::{Component, Entity, Generation};
-use {Index, World};
+use {Component, Entity, Generation, Index, World};
 
 fn create<T: Component>(world: &mut World) -> WriteStorage<T> {
     world.register::<T>();
@@ -131,7 +129,7 @@ mod test {
     impl Component for Cvec {
         type Storage = VecStorage<Cvec>;
     }
-    
+
     #[derive(PartialEq, Eq, Debug)]
     struct FlaggedCvec(u32);
     impl From<u32> for FlaggedCvec {
@@ -503,7 +501,7 @@ mod test {
 mod serialize_test {
     extern crate serde_json;
 
-    use super::{Join, VecStorage, Component, PackedData};
+    use super::{Component, Join, PackedData, VecStorage};
     use world::World;
 
     #[derive(PartialEq, Debug, Serialize, Deserialize)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,8 @@
 extern crate specs;
 extern crate rayon;
 
-use specs::prelude::*;
+use specs::{Component, DispatcherBuilder, Entities, Entity, Fetch, FetchMut, HashMapStorage,
+            InsertResult, Join, ParJoin, ReadStorage, System, VecStorage, World, WriteStorage};
 
 #[derive(Clone, Debug)]
 struct CompInt(i8);
@@ -93,13 +94,12 @@ fn dynamic_deletion() {
 
 #[test]
 fn dynamic_create_and_delete() {
-    use specs::Entities;
 
     let mut world = create_world();
 
     {
         let entities = world.entities();
-        let entities: &Entities = &*entities;
+        let entities = &*entities;
         let five: Vec<_> = entities.create_iter().take(5).collect();
 
         for e in five {
@@ -239,10 +239,8 @@ fn stillborn_entities() {
             let (entities, mut comp_int, rand) = data;
 
             for &i in rand.values.iter() {
-                use specs::InsertResult::EntityIsDead;
-
                 let result = comp_int.insert(entities.create(), CompInt(i));
-                if let EntityIsDead(_) = result {
+                if let InsertResult::EntityIsDead(_) = result {
                     panic!("Couldn't insert {} into a stillborn entity", i);
                 }
             }
@@ -408,6 +406,7 @@ fn par_join_two_components() {
 fn par_join_many_entities_and_systems() {
     use std::sync::Mutex;
     use rayon::iter::ParallelIterator;
+
     let failed = Mutex::new(vec![]);
     let mut world = create_world();
     for _ in 0..1000 {


### PR DESCRIPTION
* No crate root types, all grouped into modules
* `prelude` module reexports only `Join` and `ParJoin`
