### PR TITLE
Update to shred 0.4.2 and hibitset 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs"
-version = "0.9.0"
+version = "0.9.1"
 description = """
 Specs is an Entity-Component System library written in Rust.
 Unlike most other ECS libraries out there, it provides
@@ -29,12 +29,12 @@ travis-ci = { repository = "slide-rs/specs" }
 [dependencies]
 atom = "0.3"
 fnv = "1.0"
-hibitset = "0.1.2"
+hibitset = "0.1.3"
 mopa = "0.2"
-shred = "0.4.1"
+shred = "0.4.2"
 shred-derive = "0.3"
 tuple_utils = "0.2"
-rayon = "0.7"
+rayon = "0.7.1"
 
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
This fixes a broken build because of reliance on unstalbe rayon features. Sorry for breaking your build.

Please upgrade to Specs 0.9.1.

Fixes #193 