### PR TITLE
Change component definitions to use Self and destruct system data tuple in parameter list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [gi]: https://badges.gitter.im/slide-rs/specs.svg
 [gl]: https://gitter.im/slide-rs/specs
 
-Specs is an Entity-Component System written in Rust. 
+Specs is an Entity-Component System written in Rust.
 Unlike most other ECS libraries out there, it provides
 
 * easy parallelism
@@ -41,11 +41,11 @@ struct Vel(f32);
 struct Pos(f32);
 
 impl Component for Vel {
-    type Storage = VecStorage<Vel>;
+    type Storage = VecStorage<Self>;
 }
 
 impl Component for Pos {
-    type Storage = VecStorage<Pos>;
+    type Storage = VecStorage<Self>;
 }
 
 struct SysA;
@@ -56,13 +56,10 @@ impl<'a> System<'a> for SysA {
     // see the `full` example.
     type SystemData = (WriteStorage<'a, Pos>, ReadStorage<'a, Vel>);
 
-    fn run(&mut self, data: Self::SystemData) {
+    fn run(&mut self, (mut pos, vel): Self::SystemData) {
         // The `.join()` combines multiple components,
         // so we only access those entities which have
         // both of them.
-
-        let (mut pos, vel) = data;
-
         for (pos, vel) in (&mut pos, &vel).join() {
             pos.0 += vel.0;
         }

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -22,35 +22,35 @@ type Vec2 = Vector2<f32>;
 struct Pos(Vec2);
 
 impl Component for Pos {
-    type Storage = VecStorage<Pos>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
 struct Vel(Vec2);
 
 impl Component for Vel {
-    type Storage = VecStorage<Vel>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
 struct Force(Vec2);
 
 impl Component for Force {
-    type Storage = VecStorage<Force>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
 struct InvMass(f32);
 
 impl Component for InvMass {
-    type Storage = VecStorage<InvMass>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
 struct Lifetime(f32);
 
 impl Component for Lifetime {
-    type Storage = VecStorage<Lifetime>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -59,7 +59,7 @@ struct Ball {
 }
 
 impl Component for Ball {
-    type Storage = VecStorage<Ball>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -69,7 +69,7 @@ struct Rect {
 }
 
 impl Component for Rect {
-    type Storage = VecStorage<Rect>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -79,14 +79,14 @@ enum Spawner {
 }
 
 impl Component for Spawner {
-    type Storage = HashMapStorage<Spawner>;
+    type Storage = HashMapStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
 struct SpawnRequests(usize);
 
 impl Component for SpawnRequests {
-    type Storage = HashMapStorage<SpawnRequests>;
+    type Storage = HashMapStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -97,7 +97,7 @@ struct Collision {
 }
 
 impl Component for Collision {
-    type Storage = DenseVecStorage<Collision>;
+    type Storage = DenseVecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -107,7 +107,7 @@ struct Room {
 }
 
 impl Component for Room {
-    type Storage = HashMapStorage<Room>;
+    type Storage = HashMapStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -117,14 +117,14 @@ enum Color {
 }
 
 impl Component for Color {
-    type Storage = VecStorage<Color>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 struct KillsEnemy;
 
 impl Component for KillsEnemy {
-    type Storage = NullStorage<KillsEnemy>;
+    type Storage = NullStorage<Self>;
 }
 
 // -- Resources --
@@ -143,10 +143,8 @@ impl<'a> System<'a> for Integrate {
      ReadStorage<'a, InvMass>,
      Fetch<'a, DeltaTime>);
 
-    fn run(&mut self, data: Self::SystemData) {
+    fn run(&mut self, (mut pos, mut vel, mut force, inv_mass, delta): Self::SystemData) {
         use cgmath::Zero;
-
-        let (mut pos, mut vel, mut force, inv_mass, delta) = data;
 
         let delta: f32 = delta.0;
 
@@ -176,20 +174,23 @@ impl<'a> System<'a> for Spawn {
      WriteStorage<'a, Color>,
      WriteStorage<'a, SpawnRequests>);
 
-    fn run(&mut self, data: Self::SystemData) {
+    fn run(
+        &mut self,
+        (
+            entities,
+            spawner,
+            mut pos,
+            mut vel,
+            mut force,
+            mut inv_mass,
+            mut ball,
+            mut rect,
+            mut color,
+            mut requests
+        ): Self::SystemData
+    ) {
         use cgmath::Zero;
         use rand::Rng;
-
-        let (entities,
-             spawner,
-             mut pos,
-             mut vel,
-             mut force,
-             mut inv_mass,
-             mut ball,
-             mut rect,
-             mut color,
-             mut requests) = data;
 
         let mut rng = thread_rng();
         let mut gen = || rng.gen_range(-4.0, 4.0);

--- a/benches/world.rs
+++ b/benches/world.rs
@@ -13,14 +13,14 @@ use specs::{Component, HashMapStorage, Join, ParJoin, VecStorage, World};
 struct CompInt(i32);
 
 impl Component for CompInt {
-    type Storage = VecStorage<CompInt>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Debug)]
 struct CompBool(bool);
 
 impl Component for CompBool {
-    type Storage = HashMapStorage<CompBool>;
+    type Storage = HashMapStorage<Self>;
 }
 
 fn create_world() -> World {

--- a/book/src/02_hello_world.md
+++ b/book/src/02_hello_world.md
@@ -23,13 +23,13 @@ Let's start by creating some data:
 use specs::{Component, VecStorage};
 
 #[derive(Debug)]
-struct Position { 
-    x: f32, 
-    y: f32 
+struct Position {
+    x: f32,
+    y: f32
 }
 
 impl Component for Position {
-    type Storage = VecStorage<Position>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Debug)]
@@ -39,11 +39,11 @@ struct Velocity {
 }
 
 impl Component for Velocity {
-    type Storage = VecStorage<Velocity>;
+    type Storage = VecStorage<Self>;
 }
 ```
 
-These will be our components, stored in a `VecStorage` 
+These will be our components, stored in a `VecStorage`
 (see [the storages chapter][sc] for more details), so we can associate some data
 with an entity. Before doing that, we need to create a world, because this is
 where the storage for all the components is located.
@@ -79,7 +79,7 @@ struct HelloWorld;
 
 impl<'a> System<'a> for HelloWorld {
     type SystemData = ();
-    
+
     fn run(&mut self, data: Self::SystemData) {}
 }
 ```
@@ -99,10 +99,10 @@ struct HelloWorld;
 
 impl<'a> System<'a> for HelloWorld {
     type SystemData = ReadStorage<'a, Position>;
-    
+
     fn run(&mut self, position: Self::SystemData) {
         use specs::Join;
-    
+
         for position in position.join() {
             println!("Hello, {:?}", &position);
         }
@@ -136,13 +136,13 @@ Here the complete example of this chapter:
 use specs::{Component, ReadStorage, System, VecStorage, World, RunNow};
 
 #[derive(Debug)]
-struct Position { 
-    x: f32, 
-    y: f32 
+struct Position {
+    x: f32,
+    y: f32
 }
 
 impl Component for Position {
-    type Storage = VecStorage<Position>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Debug)]
@@ -152,17 +152,17 @@ struct Velocity {
 }
 
 impl Component for Velocity {
-    type Storage = VecStorage<Velocity>;
+    type Storage = VecStorage<Self>;
 }
 
 struct HelloWorld;
 
 impl<'a> System<'a> for HelloWorld {
     type SystemData = ReadStorage<'a, Position>;
-    
+
     fn run(&mut self, position: Self::SystemData) {
         use specs::Join;
-    
+
         for position in position.join() {
             println!("Hello, {:?}", &position);
         }
@@ -172,9 +172,9 @@ impl<'a> System<'a> for HelloWorld {
 fn main() {
     let mut world = World::new();
     world.register::<Position>();
-    
+
     world.create_entity().with(Position { x: 4.0, y: 7.0 }).build();
-    
+
     let mut hello_world = HelloWorld;
     hello_world.run_now(&world.res);
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,11 +12,11 @@ struct Vel(f32);
 struct Pos(f32);
 
 impl Component for Vel {
-    type Storage = VecStorage<Vel>;
+    type Storage = VecStorage<Self>;
 }
 
 impl Component for Pos {
-    type Storage = VecStorage<Pos>;
+    type Storage = VecStorage<Self>;
 }
 
 struct SysA;
@@ -27,13 +27,10 @@ impl<'a> System<'a> for SysA {
     // see the `full` example.
     type SystemData = (WriteStorage<'a, Pos>, ReadStorage<'a, Vel>);
 
-    fn run(&mut self, data: Self::SystemData) {
+    fn run(&mut self, (mut pos, vel): Self::SystemData) {
         // The `.join()` combines multiple components,
         // so we only access those entities which have
         // both of them.
-
-        let (mut pos, vel) = data;
-
         // You could also use `par_join()` to get a rayon `ParallelIterator`.
         for (pos, vel) in (&mut pos, &vel).join() {
             pos.0 += vel.0;

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -17,7 +17,7 @@ struct CompInt(i32);
 impl Component for CompInt {
     // Storage is used to store all data for components of this type
     // VecStorage is meant to be used for components that are in almost every entity
-    type Storage = VecStorage<CompInt>;
+    type Storage = VecStorage<Self>;
 }
 
 #[derive(Clone, Debug)]
@@ -25,14 +25,14 @@ struct CompBool(bool);
 
 impl Component for CompBool {
     // HashMapStorage is better for components that are met rarely
-    type Storage = HashMapStorage<CompBool>;
+    type Storage = HashMapStorage<Self>;
 }
 
 #[derive(Clone, Debug)]
 struct CompFloat(f32);
 
 impl Component for CompFloat {
-    type Storage = DenseVecStorage<CompFloat>;
+    type Storage = DenseVecStorage<Self>;
 }
 
 // -- Resources --
@@ -168,11 +168,8 @@ struct JoinParallel;
 impl<'a> System<'a> for JoinParallel {
     type SystemData = (ReadStorage<'a, CompInt>, WriteStorage<'a, CompFloat>);
 
-    fn run(&mut self, data: Self::SystemData) {
+    fn run(&mut self, (comp_int, mut comp_float): Self::SystemData) {
         use rayon::prelude::*;
-
-        let (comp_int, mut comp_float) = data;
-
         (&comp_int, &mut comp_float)
             .par_join()
             .for_each(|(i, f)| f.0 += i.0 as f32);

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -23,7 +23,7 @@ fn main() {
         other: bool,
     }
     impl Component for CompSerialize {
-        type Storage = VecStorage<CompSerialize>;
+        type Storage = VecStorage<Self>;
     }
 
     #[derive(SystemData)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! struct MyComp;
 //!
 //! impl Component for MyComp {
-//!     type Storage = VecStorage<MyComp>;
+//!     type Storage = VecStorage<Self>;
 //! }
 //! ```
 //!
@@ -86,11 +86,11 @@
 //! struct Pos(f32);
 //!
 //! impl Component for Vel {
-//!     type Storage = VecStorage<Vel>;
+//!     type Storage = VecStorage<Self>;
 //! }
 //!
 //! impl Component for Pos {
-//!     type Storage = VecStorage<Pos>;
+//!     type Storage = VecStorage<Self>;
 //! }
 //!
 //! struct SysA;
@@ -101,12 +101,10 @@
 //!     // see the `full` example.
 //!     type SystemData = (WriteStorage<'a, Pos>, ReadStorage<'a, Vel>);
 //!
-//!     fn run(&mut self, data: Self::SystemData) {
+//!     fn run(&mut self, (mut pos, vel): Self::SystemData) {
 //!         // The `.join()` combines multiple components,
 //!         // so we only access those entities which have
 //!         // both of them.
-//!
-//!         let (mut pos, vel) = data;
 //!
 //!         // This joins the component storages for Position
 //!         // and Velocity together; it's also possible to do this

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -59,7 +59,7 @@ unsafe impl<T> DistinctStorage for BTreeStorage<T> {}
 /// impl Component for Comp {
 ///     // `FlaggedStorage` acts as a wrapper around another storage.
 ///     // You can put any store inside of here (e.g. HashMapStorage, VecStorage, etc.)
-///     type Storage = FlaggedStorage<Comp, VecStorage<Comp>>;
+///     type Storage = FlaggedStorage<Self, VecStorage<Self>>;
 /// }
 ///
 /// pub struct CompSystem;

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -15,7 +15,7 @@ mod map_test {
     #[derive(Debug)]
     struct Comp<T>(T);
     impl<T: Any + Send + Sync> Component for Comp<T> {
-        type Storage = VecStorage<Comp<T>>;
+        type Storage = VecStorage<Self>;
     }
 
     fn ent(i: Index) -> Entity {
@@ -127,7 +127,7 @@ mod test {
         }
     }
     impl Component for Cvec {
-        type Storage = VecStorage<Cvec>;
+        type Storage = VecStorage<Self>;
     }
 
     #[derive(PartialEq, Eq, Debug)]
@@ -143,7 +143,7 @@ mod test {
         }
     }
     impl Component for FlaggedCvec {
-        type Storage = FlaggedStorage<FlaggedCvec, VecStorage<FlaggedCvec>>;
+        type Storage = FlaggedStorage<Self, VecStorage<Self>>;
     }
 
     #[derive(PartialEq, Eq, Debug)]
@@ -159,7 +159,7 @@ mod test {
         }
     }
     impl Component for Cmap {
-        type Storage = HashMapStorage<Cmap>;
+        type Storage = HashMapStorage<Self>;
     }
 
     #[derive(PartialEq, Eq, Debug)]
@@ -175,7 +175,7 @@ mod test {
         }
     }
     impl Component for CBtree {
-        type Storage = BTreeStorage<CBtree>;
+        type Storage = BTreeStorage<Self>;
     }
 
     #[derive(Clone, Debug)]
@@ -191,7 +191,7 @@ mod test {
         }
     }
     impl Component for Cnull {
-        type Storage = NullStorage<Cnull>;
+        type Storage = NullStorage<Self>;
     }
 
     fn test_add<T: Component + From<u32> + Debug + Eq>() {
@@ -510,7 +510,7 @@ mod serialize_test {
         field2: bool,
     }
     impl Component for CompTest {
-        type Storage = VecStorage<CompTest>;
+        type Storage = VecStorage<Self>;
     }
 
     #[test]


### PR DESCRIPTION
This PR changes component definitions from:
````rust
impl Component for MyTotallyRadComponent {
    type Storage = VecStorage<MyTotallyRadComponent>;
}
````
to
````rust
impl Component for MyTotallyRadComponent {
    type Storage = VecStorage<Self>;
}
````
which is shorter for long types and easier to rename. Benefits are especially great when the type has to be repeated multiple times (eg. `FlaggedStorage<MyTotallyRadComponent, VecStorage<MyTotallyRadComponent>>` vs `FlaggedStorage<Self, VecStorage<Self>>`)

It also moves system data destructuring for tuples:
````rust
fn run(&mut self, data: Self::SystemData) {
    let (first_component, mut second_component) = data;
````
to
````rust
fn run(&mut self, (first_component, mut second_component): Self::SystemData) {
````
which is shorter and conveys the fact that these component storages are takes as parameter (same way as tuple desugaring takes parameters).

NOTE: Removal of spaces at end of lines was done automatically by editor