### PR TITLE
Add other examples, required-features for serialize example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,15 @@ rand = "0.3"
 serde_json = "1.0"
 
 [[example]]
+name = "basic"
+
+[[example]]
+name = "full"
+
+[[example]]
 name = "common"
 required-features = ["common"]
+
+[[example]]
+name = "serialize"
+required-features = ["serialize"]

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,16 +1,12 @@
 extern crate shred;
-#[cfg(feature="serialize")]
 #[macro_use]
 extern crate shred_derive;
 extern crate specs;
-#[cfg(feature="serialize")]
 extern crate serde;
-#[cfg(feature="serialize")]
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 
-#[cfg(feature="serialize")]
 fn main() {
     use serde::Serialize;
     use serde_json::{Serializer, from_str as json_from_str};
@@ -112,11 +108,4 @@ fn main() {
 
     dispatcher.dispatch(&mut world.res);
     world.maintain();
-}
-
-#[cfg(not(feature="serialize"))]
-fn main() {
-    println!("This example requires the feature \"serialize\" to be enabled.");
-    println!("You can enable it temporarily with: ");
-    println!("    cargo run --example serialize --features serialize");
 }


### PR DESCRIPTION
Cargo can't seem to find the other examples without them being specified now for whatever reason, also cleans up the serialize example by using `required-features` instead of manually doing it in the example.