### PR TITLE
Make pos mut

### DIFF
--- a/book/src/04_resources.md
+++ b/book/src/04_resources.md
@@ -48,7 +48,7 @@ impl<'a> System<'a> for PosUpdate {
                        WriteStorage<'a, Position>);
                        
     fn run(&mut self, data: Self::SystemData) {
-        let (delta, vel, pos) = data;
+        let (delta, vel, mut pos) = data;
         
         // `Fetch` implements `Deref`, so it
         // coerces to `&DeltaTime`.


### PR DESCRIPTION
Without this:

> error[E0596]: cannot borrow immutable local variable `pos` as mutable
>   --> src/main.rs:52:39
>    |
> 49 |         let (delta, vel, pos) = data;
>    |                          --- consider changing this to `mut pos`
> ...
> 52 |         for (vel, pos) in (&vel, &mut pos).join() {
>    |                                       ^^^ cannot borrow mutably
> 