### PR TITLE
LazyUpdate: lazily insert and remove components, execute closures on world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Change examples to use `FooStorage<Self>` and destructure system data in method head ([#206])
 * `AntiStorage` for `ChecStorage` ([#208])
 * Integrate futures by introducing a `common` module ([#209])
-* Add lazy component insertions ([#214])
+* Add lazy updates: insert and remove components, execute closures on world ([#214], [#221])
 
 [#198]: https://github.com/slide-rs/specs/pull/198
 [#199]: https://github.com/slide-rs/specs/pull/199

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 [#208]: https://github.com/slide-rs/specs/pull/208
 [#209]: https://github.com/slide-rs/specs/pull/209
 [#214]: https://github.com/slide-rs/specs/pull/214
+[#221]: https://github.com/slide-rs/specs/pull/221

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.9.3 (Unreleased)
-* Add lazy component insertions ([#214])
+* Add lazy updates: insert and remove components, execute closures on world ([#214], [#221])
 
 [#214]: https://github.com/slide-rs/specs/pull/214
+[#221]: https://github.com/slide-rs/specs/pull/221
 
 ## 0.9.2
 * Fixed grammar in book ([#198])
@@ -10,7 +11,6 @@
 * Change examples to use `FooStorage<Self>` and destructure system data in method head ([#206])
 * `AntiStorage` for `ChecStorage` ([#208])
 * Integrate futures by introducing a `common` module ([#209])
-* Add lazy updates: insert and remove components, execute closures on world ([#214], [#221])
 
 [#198]: https://github.com/slide-rs/specs/pull/198
 [#199]: https://github.com/slide-rs/specs/pull/199
@@ -18,5 +18,3 @@
 [#206]: https://github.com/slide-rs/specs/pull/206
 [#208]: https://github.com/slide-rs/specs/pull/208
 [#209]: https://github.com/slide-rs/specs/pull/209
-[#214]: https://github.com/slide-rs/specs/pull/214
-[#221]: https://github.com/slide-rs/specs/pull/221

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub use storage::{BTreeStorage, CheckStorage, DenseVecStorage, DistinctStorage, 
                   HashMapStorage, InsertResult, NullStorage, ReadStorage, Storage,
                   UnprotectedStorage, VecStorage, WriteStorage};
 pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, EntityBuilder,
-                Generation, LazyInsert, LazyInsertions, World};
+                Generation, LazyInsert, LazyInsertions, LazyRemovals, World};
 
 #[cfg(feature = "serialize")]
 pub use storage::{MergeError, PackedData};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub use storage::{BTreeStorage, CheckStorage, DenseVecStorage, DistinctStorage, 
                   HashMapStorage, InsertResult, NullStorage, ReadStorage, Storage,
                   UnprotectedStorage, VecStorage, WriteStorage};
 pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, EntityBuilder,
-                Generation, LazyInsert, LazyUpdate, World};
+                Generation, LazyUpdate, World};
 
 #[cfg(feature = "serialize")]
 pub use storage::{MergeError, PackedData};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub use storage::{BTreeStorage, CheckStorage, DenseVecStorage, DistinctStorage, 
                   HashMapStorage, InsertResult, NullStorage, ReadStorage, Storage,
                   UnprotectedStorage, VecStorage, WriteStorage};
 pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, EntityBuilder,
-                Generation, LazyInsert, LazyInsertions, LazyRemovals, World};
+                Generation, LazyInsert, LazyUpdate, World};
 
 #[cfg(feature = "serialize")]
 pub use storage::{MergeError, PackedData};


### PR DESCRIPTION
Remove a component lazily without having to borrow its storage. To be used like this:

`let lazy = world.read_resource::<LazyUpdate>();`
`lazy.add_removal::<SomeComponentType>(some_entity);`