### PR TITLE
Add RudyStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ script:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     cargo bench --verbose --no-run;
   fi
+- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    cargo test --verbose --features rudy;
+  fi
 
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ script:
 - cargo test --verbose --no-default-features
 - cargo build --verbose --features serialize
 - cargo test --verbose --features serialize
+- cargo test --verbose --features rudy
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     cargo bench --verbose --no-run;
-  fi
-- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-    cargo test --verbose --features rudy;
   fi
 
 after_success: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
 - cargo test --verbose --no-default-features
 - cargo build --verbose --features serialize
 - cargo test --verbose --features serialize
+- cargo build --verbose --features rudy
 - cargo test --verbose --features rudy
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     cargo bench --verbose --no-run;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
 # enable rudy via -
-rudy = { optional = true, git = "https://github.com/adevore/rudy" } # pending >0.0.1 release
+rudy = { version = "0.1", optional = true }
 
 [features]
 common = ["futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ futures = { version = "0.1.14", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
-# enable rudy via -
+# enable rudy via --features rudy
 rudy = { version = "0.1", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ futures = { version = "0.1.14", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
+# enable rudy via -
+rudy = { optional = true, git = "https://github.com/adevore/rudy" } # pending >0.0.1 release
+
 [features]
 common = ["futures"]
 serialize = ["serde", "serde_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,9 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "rudy")]
+extern crate rudy;
+
 pub use join::{Join, JoinIter, JoinParIter, ParJoin};
 pub use shred::{ Dispatcher, DispatcherBuilder, Fetch, FetchId, FetchIdMut,
                 FetchMut, RunNow, RunningTime, System, SystemData};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,6 +6,8 @@ pub use self::data::{ReadStorage, WriteStorage};
 pub use self::ser::{MergeError, PackedData};
 pub use self::storages::{BTreeStorage, DenseVecStorage, FlaggedStorage, HashMapStorage,
                          NullStorage, VecStorage};
+#[cfg(feature = "rudy")]
+pub use self::storages::RudyStorage;
 
 use std;
 use std::marker::PhantomData;

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -382,3 +382,8 @@ impl<T> UnprotectedStorage<T> for RudyStorage<T> {
         self.0.remove(id).unwrap()
     }
 }
+
+// Rudy does satisfy the DistinctStorage guarantee:
+//   https://github.com/adevore/rudy/issues/12
+#[cfg(feature="rudy")]
+unsafe impl<T> DistinctStorage for RudyStorage<T> {}

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -9,6 +9,9 @@ use hibitset::BitSet;
 use world::EntityIndex;
 use {DistinctStorage, Index, Join, UnprotectedStorage};
 
+#[cfg(feature="rudy")]
+use rudy::rudymap::RudyMap;
+
 /// BTreeMap-based storage.
 pub struct BTreeStorage<T>(BTreeMap<Index, T>);
 
@@ -347,3 +350,35 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
 }
 
 unsafe impl<T> DistinctStorage for VecStorage<T> {}
+
+/// Rudy-based storage.
+#[cfg(feature="rudy")]
+pub struct RudyStorage<T>(RudyMap<Index, T>);
+
+#[cfg(feature="rudy")]
+impl<T> UnprotectedStorage<T> for RudyStorage<T> {
+    fn new() -> Self {
+        RudyStorage(Default::default())
+    }
+
+    unsafe fn clean<F>(&mut self, _: F)
+        where F: Fn(Index) -> bool
+    {
+    }
+
+    unsafe fn get(&self, id: Index) -> &T {
+        self.0.get(id).unwrap()
+    }
+
+    unsafe fn get_mut(&mut self, id: Index) -> &mut T {
+        self.0.get_mut(id).unwrap()
+    }
+
+    unsafe fn insert(&mut self, id: Index, v: T) {
+        self.0.insert(id, v);
+    }
+
+    unsafe fn remove(&mut self, id: Index) -> T {
+        self.0.remove(id).unwrap()
+    }
+}

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -178,6 +178,26 @@ mod test {
         type Storage = BTreeStorage<Self>;
     }
 
+    #[derive(PartialEq, Eq, Debug)]
+    #[cfg(feature="rudy")]
+    struct CRudy(u32);
+    #[cfg(feature="rudy")]
+    impl From<u32> for CRudy {
+        fn from(v: u32) -> CRudy {
+            CRudy(v)
+        }
+    }
+    #[cfg(feature="rudy")]
+    impl AsMut<u32> for CRudy {
+        fn as_mut(&mut self) -> &mut u32 {
+            &mut self.0
+        }
+    }
+    #[cfg(feature="rudy")]
+    impl Component for CRudy {
+        type Storage = RudyStorage<Self>;
+    }
+
     #[derive(Clone, Debug)]
     struct Cnull(u32);
     impl Default for Cnull {
@@ -396,6 +416,37 @@ mod test {
     #[test]
     fn btree_test_clear() {
         test_clear::<CBtree>();
+    }
+
+    #[cfg(feature="rudy")]
+    #[test]
+    fn rudy_test_add() {
+        test_add::<CRudy>();
+    }
+    #[cfg(feature="rudy")]
+    #[test]
+    fn rudy_test_sub() {
+        test_sub::<CRudy>();
+    }
+    #[cfg(feature="rudy")]
+    #[test]
+    fn rudy_test_get_mut() {
+        test_get_mut::<CRudy>();
+    }
+    #[cfg(feature="rudy")]
+    #[test]
+    fn rudy_test_add_gen() {
+        test_add_gen::<CRudy>();
+    }
+    #[cfg(feature="rudy")]
+    #[test]
+    fn rudy_test_sub_gen() {
+        test_sub_gen::<CRudy>();
+    }
+    #[cfg(feature="rudy")]
+    #[test]
+    fn rudy_test_clear() {
+        test_clear::<CRudy>();
     }
 
     #[test]


### PR DESCRIPTION
Per #204, `RudyStorage` presently has some caveats:

* Depends on a git checkout of `rudy`
* Depends on Rust nightly

`RudyStorage` therefore lives behind `--features rudy`. Travis now also knows about this feature flag.