### PR TITLE
Bump crossbeam, hibitset and rayon versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ travis-ci = { repository = "slide-rs/specs" }
 
 [dependencies]
 atom = "0.3"
-crossbeam = "0.2.10"
+crossbeam = "0.3.0"
 fnv = "1.0"
-hibitset = "0.1.3"
+hibitset = "0.2.0"
 mopa = "0.2"
 shred = "0.4.3"
 shred-derive = "0.3"
 tuple_utils = "0.2"
-rayon = "0.7.1"
+rayon = "0.8.2"
 
 futures = { version = "0.1.14", optional = true }
 serde = { version = "1.0", optional = true }

--- a/src/world.rs
+++ b/src/world.rs
@@ -387,6 +387,7 @@ impl<F> LazyUpdateInternal for F
 /// Please note that the provided methods take `&self`
 /// so there's no need to fetch `LazyUpdate` mutably.
 /// This resource is added to the world by default.
+#[derive(Default)]
 pub struct LazyUpdate {
     stack: TreiberStack<Box<LazyUpdateInternal>>,
 }
@@ -531,15 +532,6 @@ impl LazyUpdate {
         F: FnOnce(&World) + 'static + Send + Sync,
     {
         self.stack.push(Box::new(f));
-    }
-}
-
-impl Default for LazyUpdate {
-    fn default() -> Self {
-        // TODO: derive (`Default` is not yet implemented for `TreiberStack`)
-        LazyUpdate {
-            stack: TreiberStack::new(),
-        }
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/slide-rs/specs/issues/236

Does not bump the specs version number yet. Can be added if ready. Will compile once hibitset has been updated on crates.io.