### PR TITLE
Less scary transform for Join implementations, keeps type safety

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -275,13 +275,11 @@ impl<'a, 'e, T, D> Join for &'a mut Storage<'e, T, D>
     }
 
     unsafe fn get(v: &mut Self::Value, i: Index) -> &'a mut T {
-        use std::mem;
-
         // This is horribly unsafe. Unfortunately, Rust doesn't provide a way
         // to abstract mutable/immutable state at the moment, so we have to hack
         // our way through it.
-        let value: &'a mut Self::Value = mem::transmute(v);
-        value.get_mut(i)
+        let value: *mut Self::Value = v as *mut Self::Value;
+        (*value).get_mut(i)
     }
 }
 

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -178,9 +178,8 @@ impl<'a, C, T: UnprotectedStorage<C>> Join for &'a mut FlaggedStorage<C, T> {
     }
     unsafe fn get(v: &mut Self::Value, id: Index) -> &'a mut C {
         // similar issue here as the `Storage<T, A, D>` implementation
-        use std::mem;
-        let value: &'a mut Self::Value = mem::transmute(v);
-        value.get_mut(id)
+        let value: *mut Self::Value = v as *mut Self::Value;
+        (*value).get_mut(id)
     }
 }
 


### PR DESCRIPTION
Little less scary transformations here, since `mem::transmute` should only be used as a last resort.