### PR TITLE
Fix Merge System

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -136,7 +136,7 @@ impl<F> Merge<F> {
 struct NotifyIgnore;
 impl Notify for NotifyIgnore {
     fn notify(&self, _: usize) {
-        /* Intetionally ignore */
+        /* Intentionally ignore */
     }
 }
 


### PR DESCRIPTION
Fix `Merge` `System`
`Future`s can't be `poll`ed without `Task`.
`Spawn` creates such `Task` and provide API to run inner `Future`
Without this `Merge` will `panic!` when it'll try to call `Future::poll` except if it is trivial custom `Future`