### PR TITLE
Fix compilation error in 0.9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
 - cargo test --verbose --features serialize
 - cargo build --verbose --features rudy
 - cargo test --verbose --features rudy
+- cargo build --verbose --features common
+- cargo test --verbose --features common
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     cargo bench --verbose --no-run;
   fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.9.4
+## 0.9.5
+
+* Fixes compilation error which broke 0.9.5 ([#246])
+
+[#246]: https://github.com/slide-rs/specs/pull/246
+
+## 0.9.4 (Broken)
 
 * Fix bug in common::Merge ([#245])
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs"
-version = "0.9.4"
+version = "0.9.5"
 description = "Specs Parallel ECS"
 readme = "README.md"
 documentation = "https://docs.rs/specs/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "specs"
 version = "0.9.4"
+description = "Specs Parallel ECS"
 readme = "README.md"
 documentation = "https://docs.rs/specs/"
 repository = "https://github.com/slide-rs/specs"

--- a/src/common.rs
+++ b/src/common.rs
@@ -152,7 +152,7 @@ impl<'a, T, F> System<'a> for Merge<F>
 
     fn run(&mut self, (entities, mut errors, mut futures, mut pers): Self::SystemData) {
 
-        for (e, ()) in (&*entities, &futures.check()).join() {
+        for (e, _) in (&*entities, &futures.check()).join() {
             self.spawns.push((e, spawn(futures.remove(e).unwrap())));
         }
 


### PR DESCRIPTION
Unfortunately, there has been an error in 0.9.4 which couldn't be detected by CI. This PR ensures this doesn't happen in the future and fixes the error. Additionally, it bumps the version to 0.9.5.