### PR TITLE
Format whole codebase

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,4 @@
-reorder_imported_names = true
+reorder_imports = true
+reorder_import_names = true
+reorder_imports_in_group = true
+#imports_indent = "Block"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
 - cargo test --verbose --features serialize
 - cargo build --verbose --features rudy
 - cargo test --verbose --features rudy
+- cargo build --verbose --features common
+- cargo test --verbose --features common
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     cargo bench --verbose --no-run;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,15 @@ branches:
 
 before_script:
 - export PATH="$PATH:$HOME/.cargo/bin"
-- which rustfmt || cargo install rustfmt
+- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    which rustfmt && cargo uninstall rustfmt;
+    cargo install --force rustfmt-nightly;
+  fi
 
 script:
-- cargo fmt -- --write-mode=diff
+- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    cargo fmt -- --write-mode=diff;
+  fi
 - cargo build --verbose
 - cargo test --verbose
 - cargo build --verbose --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,20 @@ rust:
 - nightly
 - stable
 
+cache: cargo
+
 branches:
   only:
     - staging
     - trying
     - master
 
+before_script:
+- export PATH="$PATH:$HOME/.cargo/bin"
+- which rustfmt || cargo install rustfmt
+
 script:
+- cargo fmt -- --write-mode=diff
 - cargo build --verbose
 - cargo test --verbose
 - cargo build --verbose --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ exclude = ["bors.toml", ".travis.yml"]
 travis-ci = { repository = "slide-rs/specs" }
 
 [dependencies]
-atom = "0.3"
 crossbeam = "0.3.0"
 fnv = "1.0"
 hibitset = "0.2.0"

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -7,9 +7,9 @@ extern crate test;
 
 use cgmath::Vector2;
 use rand::thread_rng;
-use specs::{Component, DenseVecStorage, DispatcherBuilder, Entities, Entity,
-            Fetch, HashMapStorage, Join, NullStorage, ReadStorage, RunningTime,
-            System, VecStorage, World, WriteStorage};
+use specs::{Component, DenseVecStorage, DispatcherBuilder, Entities, Entity, Fetch,
+            HashMapStorage, Join, NullStorage, ReadStorage, RunningTime, System, VecStorage,
+            World, WriteStorage};
 use test::Bencher;
 
 type Vec2 = Vector2<f32>;
@@ -135,11 +135,13 @@ struct DeltaTime(f32);
 struct Integrate;
 
 impl<'a> System<'a> for Integrate {
-    type SystemData = (WriteStorage<'a, Pos>,
-     WriteStorage<'a, Vel>,
-     WriteStorage<'a, Force>,
-     ReadStorage<'a, InvMass>,
-     Fetch<'a, DeltaTime>);
+    type SystemData = (
+        WriteStorage<'a, Pos>,
+        WriteStorage<'a, Vel>,
+        WriteStorage<'a, Force>,
+        ReadStorage<'a, InvMass>,
+        Fetch<'a, DeltaTime>,
+    );
 
     fn run(&mut self, (mut pos, mut vel, mut force, inv_mass, delta): Self::SystemData) {
         use cgmath::Zero;
@@ -161,16 +163,18 @@ impl<'a> System<'a> for Integrate {
 struct Spawn;
 
 impl<'a> System<'a> for Spawn {
-    type SystemData = (Entities<'a>,
-     ReadStorage<'a, Spawner>,
-     WriteStorage<'a, Pos>,
-     WriteStorage<'a, Vel>,
-     WriteStorage<'a, Force>,
-     WriteStorage<'a, InvMass>,
-     WriteStorage<'a, Ball>,
-     WriteStorage<'a, Rect>,
-     WriteStorage<'a, Color>,
-     WriteStorage<'a, SpawnRequests>);
+    type SystemData = (
+        Entities<'a>,
+        ReadStorage<'a, Spawner>,
+        WriteStorage<'a, Pos>,
+        WriteStorage<'a, Vel>,
+        WriteStorage<'a, Force>,
+        WriteStorage<'a, InvMass>,
+        WriteStorage<'a, Ball>,
+        WriteStorage<'a, Rect>,
+        WriteStorage<'a, Color>,
+        WriteStorage<'a, SpawnRequests>,
+    );
 
     fn run(
         &mut self,
@@ -186,7 +190,7 @@ impl<'a> System<'a> for Spawn {
             mut color,
             mut requests
         ): Self::SystemData
-    ) {
+){
         use cgmath::Zero;
         use rand::Rng;
 
@@ -254,10 +258,12 @@ impl<'a> System<'a> for RequestSpawns {
 struct GenCollisions;
 
 impl<'a> System<'a> for GenCollisions {
-    type SystemData = (ReadStorage<'a, Pos>,
-     ReadStorage<'a, Ball>,
-     ReadStorage<'a, Rect>,
-     WriteStorage<'a, Collision>);
+    type SystemData = (
+        ReadStorage<'a, Pos>,
+        ReadStorage<'a, Ball>,
+        ReadStorage<'a, Rect>,
+        WriteStorage<'a, Collision>,
+    );
 
     fn run(&mut self, _: Self::SystemData) {
         // TODO
@@ -312,9 +318,9 @@ fn bench_parallel(b: &mut Bencher) {
             w.create_entity()
                 .with(Pos(Vec2::new(x, y)))
                 .with(Room {
-                          inner_width: width,
-                          inner_height: height,
-                      })
+                    inner_width: width,
+                    inner_height: height,
+                })
                 .build();
 
             for i in 0..4 {
@@ -337,7 +343,7 @@ fn bench_parallel(b: &mut Bencher) {
         .build();
 
     b.iter(|| {
-               d.dispatch(&mut w.res);
-               w.maintain();
-           })
+        d.dispatch(&mut w.res);
+        w.maintain();
+    })
 }

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
-extern crate test;
 extern crate specs;
+extern crate test;
 
 macro_rules! setup {
     ($num:expr => [ $( $comp:ty ),* ] ) => {
@@ -10,13 +10,13 @@ macro_rules! setup {
             $(
                 w.register::<$comp>();
             )*
-            
+
             let mut eids: Vec<_> = (0..$num)
                 .map(|i| {
                     let mut builder = w.create_entity();
                     if insert && i % sparsity == 0 {
                         $(
-                            builder = builder.with::<$comp>(<$comp>::default()); 
+                            builder = builder.with::<$comp>(<$comp>::default());
                         )*
                     }
                     builder.build()
@@ -105,7 +105,7 @@ macro_rules! tests {
             impl Component for CompBool {
                 type Storage = $storage;
             }
-            
+
             setup!(NUM => [ CompInt, CompBool ]);
 
             gap!(sparse_1 => 1);

--- a/benches/world.rs
+++ b/benches/world.rs
@@ -59,8 +59,8 @@ fn delete_now(b: &mut test::Bencher) {
     let mut w = World::new();
     let mut eids: Vec<_> = (0..10_000_000).map(|_| w.create_entity().build()).collect();
     b.iter(|| if let Some(id) = eids.pop() {
-               w.delete_entity(id)
-           });
+        w.delete_entity(id)
+    });
 }
 
 #[bench]
@@ -70,8 +70,8 @@ fn delete_now_with_storage(b: &mut test::Bencher) {
         .map(|_| w.create_entity().with(CompInt(1)).build())
         .collect();
     b.iter(|| if let Some(id) = eids.pop() {
-               w.delete_entity(id)
-           });
+        w.delete_entity(id)
+    });
 }
 
 #[bench]
@@ -79,8 +79,8 @@ fn delete_later(b: &mut test::Bencher) {
     let mut w = World::new();
     let mut eids: Vec<_> = (0..10_000_000).map(|_| w.create_entity().build()).collect();
     b.iter(|| if let Some(id) = eids.pop() {
-               w.entities().delete(id)
-           });
+        w.entities().delete(id)
+    });
 }
 
 #[bench]
@@ -93,9 +93,9 @@ fn maintain_noop(b: &mut test::Bencher) {
 fn maintain_add_later(b: &mut test::Bencher) {
     let mut w = World::new();
     b.iter(|| {
-               w.entities().create();
-               w.maintain();
-           });
+        w.entities().create();
+        w.maintain();
+    });
 }
 
 #[bench]
@@ -103,11 +103,11 @@ fn maintain_delete_later(b: &mut test::Bencher) {
     let mut w = World::new();
     let mut eids: Vec<_> = (0..10_000_000).map(|_| w.create_entity().build()).collect();
     b.iter(|| {
-               if let Some(id) = eids.pop() {
-                   w.entities().delete(id);
-               }
-               w.maintain();
-           });
+        if let Some(id) = eids.pop() {
+            w.entities().delete(id);
+        }
+        w.maintain();
+    });
 }
 
 #[bench]
@@ -126,8 +126,8 @@ fn join_single_threaded(b: &mut test::Bencher) {
     }
 
     b.iter(|| for comp in world.read::<CompInt>().join() {
-               black_box(comp.0 * comp.0);
-           })
+        black_box(comp.0 * comp.0);
+    })
 }
 
 #[bench]
@@ -147,9 +147,9 @@ fn join_multi_threaded(b: &mut test::Bencher) {
     }
 
     b.iter(|| {
-               world
-                   .read::<CompInt>()
-                   .par_join()
-                   .for_each(|comp| { black_box(comp.0 * comp.0); })
-           })
+        world
+            .read::<CompInt>()
+            .par_join()
+            .for_each(|comp| { black_box(comp.0 * comp.0); })
+    })
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 extern crate specs;
 
-use specs::{Component, DispatcherBuilder, Join, ReadStorage, System, VecStorage,
-            World, WriteStorage};
+use specs::{Component, DispatcherBuilder, Join, ReadStorage, System, VecStorage, World,
+            WriteStorage};
 
 // A component contains data which is associated with an entity.
 

--- a/examples/bitset.rs
+++ b/examples/bitset.rs
@@ -1,7 +1,7 @@
 extern crate hibitset;
 extern crate specs;
 
-use hibitset::{BitSet, BitSetAnd, BitSetLike, BitSetNot, BitSetOr};
+use hibitset::{BitSet, BitSetNot};
 use specs::Join;
 
 const COUNT: u32 = 100;

--- a/examples/bitset.rs
+++ b/examples/bitset.rs
@@ -1,9 +1,8 @@
-
-extern crate specs;
 extern crate hibitset;
+extern crate specs;
 
-use specs::{Join};
 use hibitset::{BitSet, BitSetAnd, BitSetLike, BitSetNot, BitSetOr};
+use specs::Join;
 
 const COUNT: u32 = 100;
 

--- a/examples/cluster_bomb.rs
+++ b/examples/cluster_bomb.rs
@@ -1,13 +1,14 @@
-extern crate specs;
 extern crate rand;
 extern crate rayon;
+extern crate specs;
 
 use rand::Rand;
 use rand::distributions::{IndependentSample, Range};
 
 use rayon::iter::ParallelIterator;
 
-use specs::{Component, DispatcherBuilder, Join, ParJoin, ReadStorage, System, HashMapStorage, VecStorage, DenseVecStorage, World, WriteStorage, Entities, LazyUpdate, Fetch};
+use specs::{Component, DenseVecStorage, DispatcherBuilder, Entities, Fetch, HashMapStorage, Join,
+            LazyUpdate, ParJoin, ReadStorage, System, VecStorage, World, WriteStorage};
 
 const TAU: f32 = 2. * std::f32::consts::PI;
 
@@ -57,61 +58,52 @@ impl<'a> System<'a> for ClusterBombSystem {
     fn run(&mut self, (entities, mut bombs, positions, updater): Self::SystemData) {
         let durability_range = Range::new(10, 20);
         // Join components in potentially parallel way using rayon.
-        (&*entities, &mut bombs, &positions)
-            .par_join()
-            .for_each(|(entity, bomb, position)| {
-                if bomb.fuse == 0 {
-                    entities.delete(entity);
-                    for _ in 0..9 {
-                        let shrapnel = entities.create();
-                        updater.insert(shrapnel, Shrapnel {
+        (&*entities, &mut bombs, &positions).par_join().for_each(
+            |(entity, bomb, position)| if bomb.fuse == 0 {
+                entities.delete(entity);
+                for _ in 0..9 {
+                    let shrapnel = entities.create();
+                    updater.insert(
+                        shrapnel,
+                        Shrapnel {
                             durability: durability_range.ind_sample(&mut rand::thread_rng()),
-                        });
-                        updater.insert(shrapnel, position.clone());
-                        let angle = f32::rand(&mut rand::thread_rng()) * TAU;
-                        updater.insert(shrapnel, Vel(angle.sin(), angle.cos()));
-                    }
-                } else {
-                    bomb.fuse -= 1;
+                        },
+                    );
+                    updater.insert(shrapnel, position.clone());
+                    let angle = f32::rand(&mut rand::thread_rng()) * TAU;
+                    updater.insert(shrapnel, Vel(angle.sin(), angle.cos()));
                 }
-            });
+            } else {
+                bomb.fuse -= 1;
+            },
+        );
     }
 }
 
 struct PhysicsSystem;
 impl<'a> System<'a> for PhysicsSystem {
-    type SystemData = (
-        WriteStorage<'a, Pos>,
-        ReadStorage<'a, Vel>
-    );
+    type SystemData = (WriteStorage<'a, Pos>, ReadStorage<'a, Vel>);
 
     fn run(&mut self, (mut pos, vel): Self::SystemData) {
-        (&mut pos, &vel)
-            .par_join()
-            .for_each(|(pos, vel)| {
-                pos.0 += vel.0;
-                pos.1 += vel.1;
-            });
+        (&mut pos, &vel).par_join().for_each(|(pos, vel)| {
+            pos.0 += vel.0;
+            pos.1 += vel.1;
+        });
     }
 }
 
 struct ShrapnelSystem;
 impl<'a> System<'a> for ShrapnelSystem {
-    type SystemData = (
-        Entities<'a>,
-        WriteStorage<'a, Shrapnel>,
-    );
+    type SystemData = (Entities<'a>, WriteStorage<'a, Shrapnel>);
 
     fn run(&mut self, (entities, mut shrapnels): Self::SystemData) {
-        (&*entities, &mut shrapnels)
-            .par_join()
-            .for_each(|(entity, shrapnel)| {
-                if shrapnel.durability == 0 {
-                    entities.delete(entity);
-                } else {
-                    shrapnel.durability -= 1;
-                }
-            });
+        (&*entities, &mut shrapnels).par_join().for_each(
+            |(entity, shrapnel)| if shrapnel.durability == 0 {
+                entities.delete(entity);
+            } else {
+                shrapnel.durability -= 1;
+            },
+        );
     }
 }
 
@@ -122,11 +114,10 @@ fn main() {
     world.register::<Shrapnel>();
     world.register::<ClusterBomb>();
 
-    world.create_entity()
+    world
+        .create_entity()
         .with(Pos(0., 0.))
-        .with(ClusterBomb {
-            fuse: 3
-        })
+        .with(ClusterBomb { fuse: 3 })
         .build();
 
     let mut dispatcher = DispatcherBuilder::new()
@@ -139,7 +130,8 @@ fn main() {
     loop {
         step += 1;
         let mut entities = 0;
-        { // Simple console rendering
+        {
+            // Simple console rendering
             let positions = world.read::<Pos>();
             const WIDTH: usize = 10;
             const HEIGHT: usize = 10;

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -38,9 +38,7 @@ fn main() {
 
     world.add_resource(Errors::new());
 
-    world.create_entity()
-        .with(future_sqrt(25.0))
-        .build();
+    world.create_entity().with(future_sqrt(25.0)).build();
 
     let mut dispatcher = DispatcherBuilder::new()
         .add(Merge::<MyFuture>::new(), "merge_my_float", &[])

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,15 +1,15 @@
-extern crate shred;
-#[macro_use]
-extern crate shred_derive;
-extern crate specs;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate shred;
+#[macro_use]
+extern crate shred_derive;
+extern crate specs;
 
 fn main() {
     use serde::Serialize;
-    use serde_json::{Serializer, from_str as json_from_str};
+    use serde_json::{from_str as json_from_str, Serializer};
     use specs::{Component, DispatcherBuilder, Entities, Join, PackedData, System, VecStorage,
                 World, WriteStorage};
 
@@ -73,33 +73,33 @@ fn main() {
     world
         .create_entity()
         .with(CompSerialize {
-                  field: 5,
-                  other: true,
-              })
+            field: 5,
+            other: true,
+        })
         .build();
     world.create_entity().build();
     world.create_entity().build();
     world
         .create_entity()
         .with(CompSerialize {
-                  field: 5,
-                  other: true,
-              })
+            field: 5,
+            other: true,
+        })
         .build();
     world
         .create_entity()
         .with(CompSerialize {
-                  field: 10,
-                  other: false,
-              })
+            field: 10,
+            other: false,
+        })
         .build();
     world.create_entity().build();
     world
         .create_entity()
         .with(CompSerialize {
-                  field: 0,
-                  other: false,
-              })
+            field: 0,
+            other: false,
+        })
         .build();
 
     let mut dispatcher = DispatcherBuilder::new()

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -1,7 +1,8 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
 
 use hibitset::{BitSet, BitSetAnd, BitSetLike, BitSetNot, BitSetOr};
 
-use ::{Index, Join, ParJoin};
+use {Index, Join, ParJoin};
 
 macro_rules! define_bit_join {
     ( $bitset:ident [ $( $arg:ident ),* ] ) => {
@@ -18,7 +19,7 @@ macro_rules! define_bit_join {
                 id
             }
         }
-        
+
         unsafe impl<'a, $( $arg ),*> ParJoin for &'a $bitset<$( $arg ),*>
             where $( $arg: BitSetLike ),*
         { }

--- a/src/common.rs
+++ b/src/common.rs
@@ -157,7 +157,7 @@ where
     );
 
     fn run(&mut self, (entities, mut errors, mut futures, mut pers): Self::SystemData) {
-        for (e, ()) in (&*entities, &futures.check()).join() {
+        for (e, _) in (&*entities, &futures.check()).join() {
             self.spawns.push((e, spawn(futures.remove(e).unwrap())));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,15 +199,16 @@ extern crate serde_derive;
 extern crate rudy;
 
 pub use join::{Join, JoinIter, JoinParIter, ParJoin};
-pub use shred::{Dispatcher, DispatcherBuilder, Fetch, FetchId, FetchIdMut,
-                FetchMut, RunNow, RunningTime, System, SystemData};
+pub use shred::{Dispatcher, DispatcherBuilder, Fetch, FetchId, FetchIdMut, FetchMut, RunNow,
+                RunningTime, System, SystemData};
 
 #[cfg(not(target_os = "emscripten"))]
-pub use shred::{AsyncDispatcher};
+pub use shred::AsyncDispatcher;
 
 pub use storage::{BTreeStorage, DenseVecStorage, DistinctStorage, Entry, FlaggedStorage,
-                  HashMapStorage, InsertResult, MaskedStorage, NormalRestriction, NullStorage, ParallelRestriction, ReadStorage, RestrictedStorage,
-                  Storage, UnprotectedStorage, VecStorage, WriteStorage};
+                  HashMapStorage, InsertResult, MaskedStorage, NormalRestriction, NullStorage,
+                  ParallelRestriction, ReadStorage, RestrictedStorage, Storage,
+                  UnprotectedStorage, VecStorage, WriteStorage};
 pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, EntityBuilder,
                 Generation, LazyUpdate, World};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,6 @@
 //!
 //!
 
-extern crate atom;
 extern crate crossbeam;
 extern crate fnv;
 extern crate hibitset;

--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -1,21 +1,24 @@
 use shred::{Fetch, FetchMut, ResourceId, Resources, SystemData};
 
-use storage::MaskedStorage;
 use {Component, EntitiesRes, Storage};
+use storage::MaskedStorage;
 
 /// A storage with read access.
 pub type ReadStorage<'a, T> = Storage<'a, T, Fetch<'a, MaskedStorage<T>>>;
 
 impl<'a, T> SystemData<'a> for ReadStorage<'a, T>
-    where T: Component
+where
+    T: Component,
 {
     fn fetch(res: &'a Resources, id: usize) -> Self {
         Storage::new(res.fetch(0), res.fetch(id))
     }
 
     fn reads(id: usize) -> Vec<ResourceId> {
-        vec![ResourceId::new::<EntitiesRes>(),
-             ResourceId::new_with_id::<MaskedStorage<T>>(id)]
+        vec![
+            ResourceId::new::<EntitiesRes>(),
+            ResourceId::new_with_id::<MaskedStorage<T>>(id),
+        ]
     }
 
     fn writes(_: usize) -> Vec<ResourceId> {
@@ -27,7 +30,8 @@ impl<'a, T> SystemData<'a> for ReadStorage<'a, T>
 pub type WriteStorage<'a, T> = Storage<'a, T, FetchMut<'a, MaskedStorage<T>>>;
 
 impl<'a, T> SystemData<'a> for WriteStorage<'a, T>
-    where T: Component
+where
+    T: Component,
 {
     fn fetch(res: &'a Resources, id: usize) -> Self {
         Storage::new(res.fetch(0), res.fetch_mut(id))

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -1,16 +1,19 @@
-
 use std::marker::PhantomData;
 
 use hibitset::BitSet;
 
-use world::EntityIndex;
 use {Index, Join, UnprotectedStorage};
+use world::EntityIndex;
 
 /// Wrapper storage that stores modifications to components in a bitset.
 ///
-/// **Note:** Joining over all components of a `FlaggedStorage` mutably will flag all components.**
-/// What you want to instead is to use `check()` or `restrict()` to first get the entities which contain
-/// the component, and then conditionally set the component after a call to `get_mut_unchecked()` or `get_mut()`.
+/// **Note:** Joining over all components of a `FlaggedStorage`
+/// mutably will flag all components.**
+///
+/// What you want to instead is to use `check()` or `restrict()` to first
+/// get the entities which contain the component,
+/// and then conditionally set the component
+/// after a call to `get_mut_unchecked()` or `get_mut()`.
 ///
 /// # Examples
 ///
@@ -89,7 +92,8 @@ impl<C, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedStorage<C, T>
         }
     }
     unsafe fn clean<F>(&mut self, has: F)
-        where F: Fn(Index) -> bool
+    where
+        F: Fn(Index) -> bool,
     {
         self.mask.clear();
         self.storage.clean(has);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,12 +1,11 @@
 //! Storage types
 
-pub use self::restrict::{Entry, NormalRestriction, ParallelRestriction, RestrictedStorage};
 pub use self::data::{ReadStorage, WriteStorage};
 pub use self::flagged::FlaggedStorage;
+pub use self::restrict::{Entry, NormalRestriction, ParallelRestriction, RestrictedStorage};
 #[cfg(feature = "serialize")]
 pub use self::ser::{MergeError, PackedData};
-pub use self::storages::{BTreeStorage, DenseVecStorage, HashMapStorage,
-                         NullStorage, VecStorage};
+pub use self::storages::{BTreeStorage, DenseVecStorage, HashMapStorage, NullStorage, VecStorage};
 #[cfg(feature = "rudy")]
 pub use self::storages::RudyStorage;
 
@@ -56,7 +55,8 @@ pub trait AnyStorage {
 }
 
 impl<T> AnyStorage for MaskedStorage<T>
-    where T: Component
+where
+    T: Component,
 {
     fn remove(&mut self, id: Index) -> Option<Box<Any>> {
         MaskedStorage::remove(self, id).map(|x| Box::new(x) as Box<Any>)
@@ -165,8 +165,9 @@ impl<'e, T, D> Storage<'e, T, D> {
 }
 
 impl<'e, T, D> Storage<'e, T, D>
-    where T: Component,
-          D: Deref<Target = MaskedStorage<T>>
+where
+    T: Component,
+    D: Deref<Target = MaskedStorage<T>>,
 {
     /// Tries to read the data associated with an `Entity`.
     pub fn get(&self, e: Entity) -> Option<&T> {
@@ -190,8 +191,9 @@ impl<'e, T, D> Storage<'e, T, D>
 }
 
 impl<'e, T, D> Storage<'e, T, D>
-    where T: Component,
-          D: DerefMut<Target = MaskedStorage<T>>
+where
+    T: Component,
+    D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Tries to mutate the data associated with an `Entity`.
     pub fn get_mut(&mut self, e: Entity) -> Option<&mut T> {
@@ -236,13 +238,15 @@ impl<'e, T, D> Storage<'e, T, D>
 }
 
 unsafe impl<'a, T: Component, D> DistinctStorage for Storage<'a, T, D>
-    where T::Storage: DistinctStorage
+where
+    T::Storage: DistinctStorage,
 {
 }
 
 impl<'a, 'e, T, D> Join for &'a Storage<'e, T, D>
-    where T: Component,
-          D: Deref<Target = MaskedStorage<T>>
+where
+    T: Component,
+    D: Deref<Target = MaskedStorage<T>>,
 {
     type Type = &'a T;
     type Value = &'a T::Storage;
@@ -258,8 +262,9 @@ impl<'a, 'e, T, D> Join for &'a Storage<'e, T, D>
 }
 
 impl<'a, 'e, T, D> Not for &'a Storage<'e, T, D>
-    where T: Component,
-          D: Deref<Target = MaskedStorage<T>>
+where
+    T: Component,
+    D: Deref<Target = MaskedStorage<T>>,
 {
     type Output = AntiStorage<'a>;
 
@@ -269,15 +274,17 @@ impl<'a, 'e, T, D> Not for &'a Storage<'e, T, D>
 }
 
 unsafe impl<'a, 'e, T, D> ParJoin for &'a Storage<'e, T, D>
-    where T: Component,
-          D: Deref<Target = MaskedStorage<T>>,
-          T::Storage: Sync
+where
+    T: Component,
+    D: Deref<Target = MaskedStorage<T>>,
+    T::Storage: Sync,
 {
 }
 
 impl<'a, 'e, T, D> Join for &'a mut Storage<'e, T, D>
-    where T: Component,
-          D: DerefMut<Target = MaskedStorage<T>>
+where
+    T: Component,
+    D: DerefMut<Target = MaskedStorage<T>>,
 {
     type Type = &'a mut T;
     type Value = &'a mut T::Storage;
@@ -297,9 +304,10 @@ impl<'a, 'e, T, D> Join for &'a mut Storage<'e, T, D>
 }
 
 unsafe impl<'a, 'e, T, D> ParJoin for &'a mut Storage<'e, T, D>
-    where T: Component,
-          D: DerefMut<Target = MaskedStorage<T>>,
-          T::Storage: Sync + DistinctStorage
+where
+    T: Component,
+    D: DerefMut<Target = MaskedStorage<T>>,
+    T::Storage: Sync + DistinctStorage,
 {
 }
 
@@ -311,7 +319,9 @@ pub trait UnprotectedStorage<T>: Sized {
 
     /// Clean the storage given a check to figure out if an index
     /// is valid or not. Allows us to safely drop the storage.
-    unsafe fn clean<F>(&mut self, f: F) where F: Fn(Index) -> bool;
+    unsafe fn clean<F>(&mut self, f: F)
+    where
+        F: Fn(Index) -> bool;
 
     /// Tries reading the data associated with an `Index`.
     /// This is unsafe because the external set used

--- a/src/storage/ser.rs
+++ b/src/storage/ser.rs
@@ -3,8 +3,8 @@ use std::ops::{Deref, DerefMut};
 use serde::{Deserialize, Serialize, Serializer};
 use serde::ser::SerializeStruct;
 
-use storage::MaskedStorage;
 use {Component, Entity, Index, Join, Storage, UnprotectedStorage};
+use storage::MaskedStorage;
 
 /// The error type returned
 /// by [`Storage::merge`].
@@ -44,8 +44,9 @@ impl<T> PackedData<T> {
 }
 
 impl<'e, T, D> Serialize for Storage<'e, T, D>
-    where T: Component + Serialize,
-          D: Deref<Target = MaskedStorage<T>>
+where
+    T: Component + Serialize,
+    D: Deref<Target = MaskedStorage<T>>,
 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use hibitset::BitSetLike;
@@ -69,8 +70,9 @@ impl<'e, T, D> Serialize for Storage<'e, T, D>
 }
 
 impl<'e, T, D> Storage<'e, T, D>
-    where T: Component + Deserialize<'e>,
-          D: DerefMut<Target = MaskedStorage<T>>
+where
+    T: Component + Deserialize<'e>,
+    D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Merges a list of components into the storage.
     ///
@@ -94,10 +96,11 @@ impl<'e, T, D> Storage<'e, T, D>
     /// Packed data should also be sorted in ascending order of offsets.
     /// If this is deserialized from data received from serializing a storage it will be
     /// in ascending order.
-    pub fn merge<'a>(&'a mut self,
-                     entities: &'a [Entity],
-                     mut packed: PackedData<T>)
-                     -> Result<(), MergeError> {
+    pub fn merge<'a>(
+        &'a mut self,
+        entities: &'a [Entity],
+        mut packed: PackedData<T>,
+    ) -> Result<(), MergeError> {
         for (component, offset) in packed.components.drain(..).zip(packed.offsets.iter()) {
             match entities.get(*offset as usize) {
                 Some(entity) => {

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -6,7 +6,7 @@ use fnv::FnvHashMap;
 
 use {DistinctStorage, Index, UnprotectedStorage};
 
-#[cfg(feature="rudy")]
+#[cfg(feature = "rudy")]
 use rudy::rudymap::RudyMap;
 
 /// BTreeMap-based storage.
@@ -18,7 +18,8 @@ impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
     }
 
     unsafe fn clean<F>(&mut self, _: F)
-        where F: Fn(Index) -> bool
+    where
+        F: Fn(Index) -> bool,
     {
         // nothing to do
     }
@@ -51,7 +52,8 @@ impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
     }
 
     unsafe fn clean<F>(&mut self, _: F)
-        where F: Fn(Index) -> bool
+    where
+        F: Fn(Index) -> bool,
     {
         //nothing to do
     }
@@ -94,7 +96,8 @@ impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
     }
 
     unsafe fn clean<F>(&mut self, _: F)
-        where F: Fn(Index) -> bool
+    where
+        F: Fn(Index) -> bool,
     {
         // nothing to do
     }
@@ -140,7 +143,11 @@ impl<T: Default> UnprotectedStorage<T> for NullStorage<T> {
     fn new() -> Self {
         NullStorage(Default::default())
     }
-    unsafe fn clean<F>(&mut self, _: F) where F: Fn(Index) -> bool {}
+    unsafe fn clean<F>(&mut self, _: F)
+    where
+        F: Fn(Index) -> bool,
+    {
+    }
     unsafe fn get(&self, _: Index) -> &T {
         &self.0
     }
@@ -166,7 +173,8 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
     }
 
     unsafe fn clean<F>(&mut self, has: F)
-        where F: Fn(Index) -> bool
+    where
+        F: Fn(Index) -> bool,
     {
         use std::ptr;
         for (i, v) in self.0.iter_mut().enumerate() {
@@ -209,17 +217,18 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
 unsafe impl<T> DistinctStorage for VecStorage<T> {}
 
 /// Rudy-based storage.
-#[cfg(feature="rudy")]
+#[cfg(feature = "rudy")]
 pub struct RudyStorage<T>(RudyMap<Index, T>);
 
-#[cfg(feature="rudy")]
+#[cfg(feature = "rudy")]
 impl<T> UnprotectedStorage<T> for RudyStorage<T> {
     fn new() -> Self {
         RudyStorage(Default::default())
     }
 
     unsafe fn clean<F>(&mut self, _: F)
-        where F: Fn(Index) -> bool
+    where
+        F: Fn(Index) -> bool,
     {
     }
 
@@ -242,5 +251,5 @@ impl<T> UnprotectedStorage<T> for RudyStorage<T> {
 
 // Rudy does satisfy the DistinctStorage guarantee:
 //   https://github.com/adevore/rudy/issues/12
-#[cfg(feature="rudy")]
+#[cfg(feature = "rudy")]
 unsafe impl<T> DistinctStorage for RudyStorage<T> {}

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -185,21 +185,21 @@ mod test {
     }
 
     #[derive(PartialEq, Eq, Debug)]
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     struct CRudy(u32);
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     impl From<u32> for CRudy {
         fn from(v: u32) -> CRudy {
             CRudy(v)
         }
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     impl AsMut<u32> for CRudy {
         fn as_mut(&mut self) -> &mut u32 {
             &mut self.0
         }
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     impl Component for CRudy {
         type Storage = RudyStorage<Self>;
     }
@@ -229,8 +229,10 @@ mod test {
         }
 
         for i in 0..1_000 {
-            assert_eq!(s.get(Entity::new(i, Generation::new(1))).unwrap(),
-                       &(i + 2718).into());
+            assert_eq!(
+                s.get(Entity::new(i, Generation::new(1))).unwrap(),
+                &(i + 2718).into()
+            );
         }
     }
 
@@ -243,8 +245,10 @@ mod test {
         }
 
         for i in 0..1_000 {
-            assert_eq!(s.remove(Entity::new(i, Generation::new(1))).unwrap(),
-                       (i + 2718).into());
+            assert_eq!(
+                s.remove(Entity::new(i, Generation::new(1))).unwrap(),
+                (i + 2718).into()
+            );
             assert!(s.remove(Entity::new(i, Generation::new(1))).is_none());
         }
     }
@@ -264,8 +268,10 @@ mod test {
         }
 
         for i in 0..1_000 {
-            assert_eq!(s.get(Entity::new(i, Generation::new(1))).unwrap(),
-                       &(i + 2000).into());
+            assert_eq!(
+                s.get(Entity::new(i, Generation::new(1))).unwrap(),
+                &(i + 2000).into()
+            );
         }
     }
 
@@ -280,8 +286,10 @@ mod test {
 
         for i in 0..1_000 {
             assert!(s.get(Entity::new(i, Generation::new(2))).is_none());
-            assert_eq!(s.get(Entity::new(i, Generation::new(1))).unwrap(),
-                       &(i + 2718).into());
+            assert_eq!(
+                s.get(Entity::new(i, Generation::new(1))).unwrap(),
+                &(i + 2718).into()
+            );
         }
     }
 
@@ -424,32 +432,32 @@ mod test {
         test_clear::<CBtree>();
     }
 
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     #[test]
     fn rudy_test_add() {
         test_add::<CRudy>();
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     #[test]
     fn rudy_test_sub() {
         test_sub::<CRudy>();
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     #[test]
     fn rudy_test_get_mut() {
         test_get_mut::<CRudy>();
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     #[test]
     fn rudy_test_add_gen() {
         test_add_gen::<CRudy>();
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     #[test]
     fn rudy_test_sub_gen() {
         test_sub_gen::<CRudy>();
     }
-    #[cfg(feature="rudy")]
+    #[cfg(feature = "rudy")]
     #[test]
     fn rudy_test_clear() {
         test_clear::<CRudy>();
@@ -477,18 +485,24 @@ mod test {
         }
 
         for (entry, restricted) in (&mut s1.restrict()).join() {
-            let c1 = {
-                restricted.get_unchecked(&entry).0
-            };
+            let c1 = { restricted.get_unchecked(&entry).0 };
 
-            let c2 = {
-                restricted.get_mut_unchecked(&entry).0
-            };
+            let c2 = { restricted.get_mut_unchecked(&entry).0 };
 
-            assert_eq!(c1, c2, "Mutable and immutable gets returned different components.");
-            assert!(components.remove(&c1), "Same component was iterated twice in join.");
+            assert_eq!(
+                c1,
+                c2,
+                "Mutable and immutable gets returned different components."
+            );
+            assert!(
+                components.remove(&c1),
+                "Same component was iterated twice in join."
+            );
         }
-        assert!(components.is_empty(), "Some components weren't iterated in join.");
+        assert!(
+            components.is_empty(),
+            "Some components weren't iterated in join."
+        );
     }
 
     #[test]
@@ -512,15 +526,25 @@ mod test {
         let components2 = Mutex::new(Vec::new());
         let components2_mut = Mutex::new(Vec::new());
 
-        (&mut s1.par_restrict()).par_join()
+        (&mut s1.par_restrict())
+            .par_join()
             .for_each(|(entry, restricted)| {
-                let (mut components2, mut components2_mut) = (components2.lock().unwrap(), components2_mut.lock().unwrap());
+                let (mut components2, mut components2_mut) =
+                    (components2.lock().unwrap(), components2_mut.lock().unwrap());
                 components2.push(restricted.get_unchecked(&entry).0);
                 components2_mut.push(restricted.get_mut_unchecked(&entry).0);
             });
         let components2 = components2.into_inner().unwrap();
-        assert_eq!(components2, components2_mut.into_inner().unwrap(), "Mutable and immutable gets returned different components.");
-        assert_eq!(components, components2.into_iter().collect(), "Components iterated weren't as should've been.");
+        assert_eq!(
+            components2,
+            components2_mut.into_inner().unwrap(),
+            "Mutable and immutable gets returned different components."
+        );
+        assert_eq!(
+            components,
+            components2.into_iter().collect(),
+            "Components iterated weren't as should've been."
+        );
     }
 
     #[test]
@@ -561,7 +585,8 @@ mod test {
             s1.insert(Entity::new(i, Generation::new(1)), (i + 10).into());
             s2.insert(Entity::new(i, Generation::new(1)), (i + 10).into());
         }
-        (&mut s1.par_restrict(), &mut s2.par_restrict()).par_join()
+        (&mut s1.par_restrict(), &mut s2.par_restrict())
+            .par_join()
             .for_each(|((s1_entry, _), (_, s2_restricted))| {
                 // verify that the assert fails if the storage is not the original.
                 s2_restricted.get_unchecked(&s1_entry);
@@ -583,8 +608,7 @@ mod test {
         for (entity, id) in (&*w.entities(), &s1.check()).join() {
             if id % 3 == 0 {
                 let _ = s1.get_mut(entity);
-            }
-            else {
+            } else {
                 let _ = s1.get(entity);
             }
         }
@@ -688,32 +712,35 @@ mod serialize_test {
         world
             .create_entity()
             .with(CompTest {
-                      field1: 0,
-                      field2: true,
-                  })
+                field1: 0,
+                field2: true,
+            })
             .build();
         world.create_entity().build();
         world.create_entity().build();
         world
             .create_entity()
             .with(CompTest {
-                      field1: 158123,
-                      field2: false,
-                  })
+                field1: 158123,
+                field2: false,
+            })
             .build();
         world
             .create_entity()
             .with(CompTest {
-                      field1: u32::max_value(),
-                      field2: false,
-                  })
+                field1: u32::max_value(),
+                field2: false,
+            })
             .build();
         world.create_entity().build();
 
         let storage = world.read::<CompTest>();
         let serialized = serde_json::to_string(&storage).unwrap();
-        assert_eq!(serialized,
-                   r#"{"offsets":[1,4,5],"components":[{"field1":0,"field2":true},{"field1":158123,"field2":false},{"field1":4294967295,"field2":false}]}"#);
+        assert_eq!(
+            serialized,
+            r#"{"offsets":[1,4,5],"components":[{"field1":0,"field2":true},"#.to_owned() +
+                r#"{"field1":158123,"field2":false},{"field1":4294967295,"field2":false}]}"#
+        );
     }
 
     #[test]
@@ -747,40 +774,50 @@ mod serialize_test {
         let mut storage = world.write::<CompTest>();
         let packed: PackedData<CompTest> = serde_json::from_str(&data).unwrap();
         assert_eq!(packed.offsets, vec![3, 7, 8]);
-        assert_eq!(packed.components,
-                   vec![CompTest {
-                            field1: 0,
-                            field2: true,
-                        },
-                        CompTest {
-                            field1: 158123,
-                            field2: false,
-                        },
-                        CompTest {
-                            field1: u32::max_value(),
-                            field2: false,
-                        }]);
+        assert_eq!(
+            packed.components,
+            vec![
+                CompTest {
+                    field1: 0,
+                    field2: true,
+                },
+                CompTest {
+                    field1: 158123,
+                    field2: false,
+                },
+                CompTest {
+                    field1: u32::max_value(),
+                    field2: false,
+                },
+            ]
+        );
 
         storage
             .merge(&entities.as_slice(), packed)
             .expect("Failed to merge into storage");
 
         assert_eq!((&storage).join().count(), 3);
-        assert_eq!((&storage).get(entities[3]),
-                   Some(&CompTest {
-                            field1: 0,
-                            field2: true,
-                        }));
-        assert_eq!((&storage).get(entities[7]),
-                   Some(&CompTest {
-                            field1: 158123,
-                            field2: false,
-                        }));
-        assert_eq!((&storage).get(entities[8]),
-                   Some(&CompTest {
-                            field1: u32::max_value(),
-                            field2: false,
-                        }));
+        assert_eq!(
+            (&storage).get(entities[3]),
+            Some(&CompTest {
+                field1: 0,
+                field2: true,
+            })
+        );
+        assert_eq!(
+            (&storage).get(entities[7]),
+            Some(&CompTest {
+                field1: 158123,
+                field2: false,
+            })
+        );
+        assert_eq!(
+            (&storage).get(entities[8]),
+            Some(&CompTest {
+                field1: u32::max_value(),
+                field2: false,
+            })
+        );
 
         let none = vec![0, 1, 2, 4, 5, 6, 9];
         for entity in none {

--- a/src/world.rs
+++ b/src/world.rs
@@ -5,13 +5,13 @@ use hibitset::{AtomicBitSet, BitSet, BitSetOr};
 use mopa::Any;
 use shred::{Fetch, FetchMut, Resource, Resources};
 
-use storage::{AnyStorage, MaskedStorage};
 use {Index, Join, ParJoin, ReadStorage, Storage, UnprotectedStorage, WriteStorage};
+use storage::{AnyStorage, MaskedStorage};
 
 const COMPONENT_NOT_REGISTERED: &str = "No component with the given id. Did you forget to register \
-the component with `World::register::<ComponentName>()`?";
+                                        the component with `World::register::<ComponentName>()`?";
 const RESOURCE_NOT_ADDED: &str = "No resource with the given id. Did you forget to add \
-the resource with `World::add_resource(resource)`?";
+                                  the resource with `World::add_resource(resource)`?";
 
 /// Internally used structure for `Entity` allocation.
 #[derive(Default, Debug)]
@@ -43,8 +43,7 @@ impl Allocator {
 
     /// Return `true` if the entity is alive.
     fn is_alive(&self, e: Entity) -> bool {
-        e.gen() ==
-        match self.generations.get(e.id() as usize) {
+        e.gen() == match self.generations.get(e.id() as usize) {
             Some(g) if !g.is_alive() && self.raised.contains(e.id()) => g.raised(),
             Some(g) => *g,
             None => Generation(1),
@@ -62,8 +61,9 @@ impl Allocator {
             }
 
             if start_from ==
-               self.start_from
-                   .compare_and_swap(current, start_from, Ordering::Relaxed) {
+                self.start_from
+                    .compare_and_swap(current, start_from, Ordering::Relaxed)
+            {
                 return;
             }
         }
@@ -372,7 +372,8 @@ trait LazyUpdateInternal: Send + Sync {
 }
 
 impl<F> LazyUpdateInternal for F
-    where F: FnOnce(&World) + Send + Sync + 'static
+where
+    F: FnOnce(&World) + Send + Sync + 'static,
 {
     fn update(self: Box<Self>, world: &World) {
         self(world);
@@ -418,11 +419,10 @@ impl LazyUpdate {
     /// }
     /// ```
     pub fn insert<C>(&self, e: Entity, c: C)
-        where C: Component + Send + Sync,
+    where
+        C: Component + Send + Sync,
     {
-        self.execute(move |world| {
-            world.write::<C>().insert(e, c);
-        });
+        self.execute(move |world| { world.write::<C>().insert(e, c); });
     }
 
     /// Lazily inserts components for entities.
@@ -452,9 +452,9 @@ impl LazyUpdate {
     /// }
     /// ```
     pub fn insert_all<C, I>(&self, iter: I)
-        where 
-            C: Component + Send + Sync,
-            I: IntoIterator<Item=(Entity, C)> + Send + Sync + 'static,
+    where
+        C: Component + Send + Sync,
+        I: IntoIterator<Item = (Entity, C)> + Send + Sync + 'static,
     {
         self.execute(move |world| {
             let mut storage = world.write::<C>();
@@ -493,9 +493,7 @@ impl LazyUpdate {
     where
         C: Component + Send + Sync,
     {
-        self.execute(move |world| {
-            world.write::<C>().remove(e);
-        });
+        self.execute(move |world| { world.write::<C>().remove(e); });
     }
 
     /// Lazily executes a closure with world access.
@@ -516,7 +514,7 @@ impl LazyUpdate {
     /// impl<'a> System<'a> for Execution {
     ///     type SystemData = (Entities<'a>, Fetch<'a, LazyUpdate>);
     ///
-    ///     fn run(&mut self, (ent, lazy): Self::SystemData) {      
+    ///     fn run(&mut self, (ent, lazy): Self::SystemData) {
     ///         for entity in ent.join() {
     ///             lazy.execute(move |world| {
     ///                 if world.is_alive(entity) {
@@ -591,7 +589,8 @@ impl World {
         use shred::ResourceId;
 
         if self.res
-               .has_value(ResourceId::new_with_id::<MaskedStorage<T>>(id)) {
+            .has_value(ResourceId::new_with_id::<MaskedStorage<T>>(id))
+        {
             return;
         }
 
@@ -835,8 +834,8 @@ impl Default for World {
 
 #[cfg(test)]
 mod tests {
-    use storage::VecStorage;
     use super::*;
+    use storage::VecStorage;
 
     struct Pos;
 
@@ -865,7 +864,7 @@ mod tests {
             e1 = entities.create();
             e2 = entities.create();
             lazy.insert(e1, Pos);
-            lazy.insert_all(vec! [(e1, Vel), (e2, Vel)]);
+            lazy.insert_all(vec![(e1, Vel), (e2, Vel)]);
         }
 
         world.maintain();
@@ -873,7 +872,7 @@ mod tests {
         assert!(world.read::<Vel>().get(e1).is_some());
         assert!(world.read::<Vel>().get(e2).is_some());
     }
-    
+
     #[test]
     fn lazy_removal() {
         let mut world = World::new();
@@ -900,9 +899,7 @@ mod tests {
         };
         {
             let lazy = world.read_resource::<LazyUpdate>();
-            lazy.execute(move |world| {
-                world.write::<Pos>().insert(e, Pos);
-            });
+            lazy.execute(move |world| { world.write::<Pos>().insert(e, Pos); });
         }
 
         world.maintain();


### PR DESCRIPTION
The new formatting makes diffs for imports easier to read by using vertical formatting if horizontal doesn't work.