### PR TITLE
Remove useless lifetime parameter from tuple `impl` heads.

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -225,7 +225,7 @@ where
 macro_rules! define_open {
     // use variables to indicate the arity of the tuple
     ($($from:ident),*) => {
-        impl<'a, $($from,)*> Join for ($($from),*,)
+        impl<$($from,)*> Join for ($($from),*,)
             where $($from: Join),*,
                   ($(<$from as Join>::Mask,)*): BitAnd,
         {
@@ -248,7 +248,7 @@ macro_rules! define_open {
                 ($($from::get($from, i),)*)
             }
         }
-        unsafe impl<'a, $($from,)*> ParJoin for ($($from),*,)
+        unsafe impl<$($from,)*> ParJoin for ($($from),*,)
             where $($from: ParJoin),*,
                   ($(<$from as Join>::Mask,)*): BitAnd,
         {}


### PR DESCRIPTION
This was bugging me while reading the docs; this has absolutely zero possible effect, except to maybe make both `rustc` and outside readers slightly more efficient at scanning the code.