### PR TITLE
Code coverage using cargo-travis on coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,20 @@ rust:
 - nightly
 - stable
 
-cache: cargo
+cache:
+  cargo: true
+  apt: true
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev
+      - cmake
+    sources:
+      - kalakris-cmake
 
 branches:
   only:
@@ -12,6 +25,7 @@ branches:
     - master
 
 before_script:
+- cargo install --force cargo-travis
 - export PATH="$PATH:$HOME/.cargo/bin"
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
     which rustfmt && cargo uninstall rustfmt;
@@ -39,6 +53,9 @@ script:
 - cargo test --manifest-path ./specs-derive/Cargo.toml --verbose
 
 after_success: |
+  if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then
+    cargo coveralls --exclude-pattern tests/;
+  fi
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
   [ $TRAVIS_RUST_VERSION = stable ] &&

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **S**pecs **P**arallel **ECS**
 
-[![Build Status][bi]][bl] [![Crates.io][ci]][cl] [![Gitter][gi]][gl] ![MIT/Apache][li] [![Docs.rs][di]][dl]
+[![Build Status][bi]][bl] [![Crates.io][ci]][cl] [![Gitter][gi]][gl] ![MIT/Apache][li] [![Docs.rs][di]][dl] [![Coverage][cci]][ccl]
 
 [bi]: https://travis-ci.org/slide-rs/specs.svg?branch=master
 [bl]: https://travis-ci.org/slide-rs/specs
@@ -17,6 +17,9 @@
 
 [gi]: https://badges.gitter.im/slide-rs/specs.svg
 [gl]: https://gitter.im/slide-rs/specs
+
+[cci]: https://coveralls.io/repos/github/slide-rs/specs/badge.svg?branch=master
+[ccl]: https://coveralls.io/github/slide-rs/specs?branch=master
 
 Specs is an Entity-Component System written in Rust.
 Unlike most other ECS libraries out there, it provides


### PR DESCRIPTION
This PR adds automatic code coverage testing using `cargo-travis` and `coveralls`.

Note: I cannot add the repo to coveralls as I am not member of the github organization.