### PR TITLE
Adds StorageEntry to Storage for convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 * Add `saveload` module for easy entity serialization ([#275])
 * Improve docs, book and examples ([#278], [#281], [#283], [#285])
 * Add `EntityBuilder::marked` convenience method ([#287])
+* Add `StorageEntry` for easier handling of inserting/removing component ([#274])
 
+[#274]: https://github.com/slide-rs/specs/pull/274
 [#275]: https://github.com/slide-rs/specs/pull/275
 [#278]: https://github.com/slide-rs/specs/pull/278
 [#281]: https://github.com/slide-rs/specs/pull/281

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -188,9 +188,9 @@ impl<'a> System<'a> for Spawn {
             mut ball,
             mut rect,
             mut color,
-            mut requests
-        ): Self::SystemData
-){
+            mut requests,
+        ): Self::SystemData,
+    ) {
         use cgmath::Zero;
         use rand::Rng;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,19 +146,3 @@ impl StdError for NoError {
         match *self {}
     }
 }
-
-/// Storage entry error when the request entity was dead.
-#[derive(Debug)]
-pub struct EntryIsDead(pub Entity);
-
-impl Display for EntryIsDead {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "Attempted to get an entry for entity {:?} after it died.", self.0)
-    }
-}
-
-impl StdError for EntryIsDead {
-    fn description(&self) -> &str {
-        "Attempted to get a storage entry for an entity that is no longer valid/alive"
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -129,7 +129,6 @@ impl StdError for WrongGeneration {
     }
 }
 
-
 /// An error type which cannot be instantiated.
 /// Used as a placeholder for associated error types if
 /// something cannot fail.
@@ -145,5 +144,21 @@ impl Display for NoError {
 impl StdError for NoError {
     fn description(&self) -> &str {
         match *self {}
+    }
+}
+
+/// Storage entry error when the request entity was dead.
+#[derive(Debug)]
+pub struct EntryIsDead(pub Entity);
+
+impl Display for EntryIsDead {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Attempted to get an entry for entity {:?} after it died.", self.0)
+    }
+}
+
+impl StdError for EntryIsDead {
+    fn description(&self) -> &str {
+        "Attempted to get a storage entry for an entity that is no longer valid/alive"
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,8 +216,8 @@ pub use shred::AsyncDispatcher;
 
 pub use storage::{BTreeStorage, Change, ChangeEvents, DenseVecStorage, DistinctStorage, Entry,
                   FlaggedStorage, HashMapStorage, InsertResult, MaskedStorage, NormalRestriction,
-                  NullStorage, ParallelRestriction, ReadStorage, RestrictedStorage, Storage,
-                  TrackedStorage, UnprotectedStorage, VecStorage, WriteStorage};
+                  OccupiedEntry, NullStorage, ParallelRestriction, ReadStorage, RestrictedStorage, Storage,
+                  StorageEntry, TrackedStorage, UnprotectedStorage, VacantEntry, VecStorage, WriteStorage};
 pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, EntityBuilder,
                 Generation, LazyUpdate, World};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,8 +216,9 @@ pub use shred::AsyncDispatcher;
 
 pub use storage::{BTreeStorage, Change, ChangeEvents, DenseVecStorage, DistinctStorage, Entry,
                   FlaggedStorage, HashMapStorage, InsertResult, MaskedStorage, NormalRestriction,
-                  OccupiedEntry, NullStorage, ParallelRestriction, ReadStorage, RestrictedStorage, Storage,
-                  StorageEntry, TrackedStorage, UnprotectedStorage, VacantEntry, VecStorage, WriteStorage};
+                  NullStorage, OccupiedEntry, ParallelRestriction, ReadStorage, RestrictedStorage,
+                  Storage, StorageEntry, TrackedStorage, UnprotectedStorage, VacantEntry,
+                  VecStorage, WriteStorage};
 pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, EntityBuilder,
                 Generation, LazyUpdate, World};
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -217,7 +217,13 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Get a mutable reference to the component associated with the entity.
-    pub fn get_mut(self) -> &'a mut T {
+    pub fn get_mut(&mut self) -> &mut T {
+        unsafe { self.storage.data.inner.get_mut(self.entity.id()) }
+    }
+
+    /// Converts the `OccupiedEntry` into a mutable reference bounded by
+    /// the storage's lifetime.
+    pub fn into_mut(self) -> &'a mut T {
         unsafe { self.storage.data.inner.get_mut(self.entity.id()) }
     }
 
@@ -281,8 +287,8 @@ where
         F: FnOnce() -> T,
     {
         match self {
-            StorageEntry::Occupied(occupied) => occupied.get_mut(),
-            StorageEntry::Vacant(vacant) => vacant.insert(component()),
+            StorageEntry::Occupied(occupied) => occupied.into_mut(),
+            StorageEntry::Vacant(vacant) => vacant.insert(default()),
         }
     }
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -559,6 +559,52 @@ mod test {
     }
 
     #[test]
+    fn storage_entry() {
+        let mut w = World::new();
+        w.register::<Cvec>();
+
+        let e1 = w.create_entity().build();
+        let e2 = w.create_entity().with(Cvec(10)).build();
+
+        let e3 = w.create_entity().build();
+        let e4 = w.create_entity().with(Cvec(10)).build();
+
+        let mut s1 = w.write::<Cvec>();
+        if let Ok(entry) = s1.entry(e1) {
+            entry.or_insert(Cvec(5));
+        }
+
+        if let Ok(entry) = s1.entry(e2) {
+            entry.or_insert(Cvec(5));
+        }
+
+        let mut increment = 0;
+        if let Ok(entry) = s1.entry(e3) {
+            entry.or_insert_with(|| {
+                increment += 1;
+                Cvec(5)
+            });
+
+            assert_eq!(increment, 1);
+        }
+
+        if let Ok(entry) = s1.entry(e4) {
+            entry.or_insert_with(|| {
+                increment += 1;
+                Cvec(5)
+            });
+
+            // Should not have been incremented.
+            assert_eq!(increment, 1);
+        }
+
+        assert_eq!(*s1.get(e1).unwrap(), Cvec(5));
+        assert_eq!(*s1.get(e2).unwrap(), Cvec(10));
+        assert_eq!(*s1.get(e3).unwrap(), Cvec(5));
+        assert_eq!(*s1.get(e4).unwrap(), Cvec(10));
+    }
+
+    #[test]
     #[should_panic]
     fn wrong_storage() {
         use join::Join;

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -586,16 +586,15 @@ mod test {
         // Verify that lazy closures are called only when inserted.
         {
             let mut increment = 0;
-            let mut lazy_increment = |entity: Entity, valid: u32| {
-                if let Ok(entry) = s1.entry(entity) {
+            let mut lazy_increment =
+                |entity: Entity, valid: u32| if let Ok(entry) = s1.entry(entity) {
                     entry.or_insert_with(|| {
                         increment += 1;
                         Cvec(5)
                     });
 
                     assert_eq!(increment, valid);
-                }
-            };
+                };
 
             lazy_increment(e3, 1);
             lazy_increment(e4, 1);
@@ -605,7 +604,7 @@ mod test {
         {
             let mut occupied = |entity, value| {
                 assert_eq!(*s1.get(entity).unwrap(), value);
-                
+
                 match s1.entry(entity) {
                     Ok(StorageEntry::Occupied(occupied)) => assert_eq!(*occupied.get_mut(), value),
                     _ => panic!("Entity not occupied {:?}", entity),
@@ -620,12 +619,14 @@ mod test {
 
         // Swap between occupied and vacant depending on the type of entry.
         {
-            let mut toggle = |entity: Entity| {
-                match s1.entry(entity) {
-                    Ok(StorageEntry::Occupied(occupied)) => { occupied.remove(); },
-                    Ok(StorageEntry::Vacant(vacant)) => { vacant.insert(Cvec(15)); },
-                    Err(_) => { },
+            let mut toggle = |entity: Entity| match s1.entry(entity) {
+                Ok(StorageEntry::Occupied(occupied)) => {
+                    occupied.remove();
                 }
+                Ok(StorageEntry::Vacant(vacant)) => {
+                    vacant.insert(Cvec(15));
+                }
+                Err(_) => {}
             };
 
             toggle(e5);

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -606,7 +606,9 @@ mod test {
                 assert_eq!(*s1.get(entity).unwrap(), value);
 
                 match s1.entry(entity) {
-                    Ok(StorageEntry::Occupied(occupied)) => assert_eq!(*occupied.get_mut(), value),
+                    Ok(StorageEntry::Occupied(mut occupied)) => {
+                        assert_eq!(*occupied.get_mut(), value)
+                    }
                     _ => panic!("Entity not occupied {:?}", entity),
                 }
             };

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -8,7 +8,7 @@ use error::WrongGeneration;
 /// Internally used structure for `Entity` allocation.
 #[derive(Default, Debug)]
 pub struct Allocator {
-    pub(super) generations: Vec<Generation>,
+    pub(crate) generations: Vec<Generation>,
 
     alive: BitSet,
     raised: AtomicBitSet,
@@ -230,7 +230,7 @@ impl Entity {
 /// entities with this struct.
 #[derive(Debug, Default)]
 pub struct EntitiesRes {
-    pub(super) alloc: Allocator,
+    pub(crate) alloc: Allocator,
 }
 
 impl EntitiesRes {
@@ -294,7 +294,7 @@ unsafe impl<'a> ParJoin for &'a EntitiesRes {}
 /// it bumps the `Generation` by 1. This allows to avoid using components
 /// from the entities that were deleted.
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Generation(i32);
+pub struct Generation(pub(crate) i32);
 
 impl Generation {
     #[cfg(test)]


### PR DESCRIPTION
Fixes #268 

Adds `StorageEntry` to allow for in place insertions, also some other methods for dealing with the occupied and vacant entries, similar to `std`s HashMap Entry.

Still need to add some tests for further verification (I'll do this tomorrow).