### PR TITLE
Add an ability to save and load entities.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -128,3 +128,22 @@ impl StdError for WrongGeneration {
          (e.g. because the entity has been deleted)"
     }
 }
+
+
+/// An error type which cannot be instantiated.
+/// Used as a placeholder for associated error types if
+/// something cannot fail.
+#[derive(Debug)]
+pub enum NoError {}
+
+impl Display for NoError {
+    fn fmt(&self, _: &mut Formatter) -> FmtResult {
+        match *self {}
+    }
+}
+
+impl StdError for NoError {
+    fn description(&self) -> &str {
+        match *self {}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,9 @@ extern crate futures;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate shred_derive;
 
 #[cfg(feature = "rudy")]
 extern crate rudy;
@@ -213,6 +216,9 @@ pub use world::{Component, CreateIter, CreateIterAtomic, EntitiesRes, Entity, En
 
 #[cfg(feature = "common")]
 pub mod common;
+
+#[cfg(feature = "serde")]
+pub mod saveload;
 
 #[cfg(feature = "rudy")]
 pub use storage::RudyStorage;

--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -1,4 +1,3 @@
-
 use std::fmt::{self, Display, Formatter};
 use std::marker::PhantomData;
 
@@ -47,7 +46,7 @@ where
         let ids = |marker: M::Identifier| Some(allocator.get_marked(marker, entities, markers));
         match T::load(entity, data.components, storages, ids) {
             Ok(()) => Ok(()),
-            Err(err) => Err(de::Error::custom(err))
+            Err(err) => Err(de::Error::custom(err)),
         }
     }
 }
@@ -83,7 +82,9 @@ where
             markers: self.markers,
             allocator: self.allocator,
             pd: self.pd,
-        })?.is_some() {}
+        })?
+            .is_some()
+        {}
 
         Ok(())
     }

--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -1,0 +1,147 @@
+
+use std::fmt::{self, Display, Formatter};
+use std::marker::PhantomData;
+
+use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
+
+use {Entities, FetchMut, WriteStorage};
+
+use saveload::{Components, EntityData, Storages};
+use saveload::marker::{Marker, MarkerAllocator};
+
+
+/// Wrapper for `Entity` and tuple of `WriteStorage`s that implements `serde::Deserialize`
+struct DeserializeEntity<'a, 'b: 'a, M: Marker, E, T: Components<M::Identifier, E>> {
+    entities: &'a Entities<'b>,
+    storages: &'a mut <T as Storages<'b>>::WriteStorages,
+    markers: &'a mut WriteStorage<'b, M>,
+    allocator: &'a mut FetchMut<'b, M::Allocator>,
+    pd: PhantomData<(M, E, T)>,
+}
+
+impl<'de, 'a, 'b: 'a, M, E, T> DeserializeSeed<'de> for DeserializeEntity<'a, 'b, M, E, T>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+{
+    type Value = ();
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let DeserializeEntity {
+            entities,
+            storages,
+            markers,
+            allocator,
+            ..
+        } = self;
+        let data = EntityData::<M, E, T>::deserialize(deserializer)?;
+        let entity = allocator.get_marked(data.marker.id(), entities, markers);
+        markers
+            .get_mut(entity)
+            .ok_or("Allocator is broken")
+            .map_err(de::Error::custom)?
+            .update(data.marker);
+        let ids = |marker: M::Identifier| Some(allocator.get_marked(marker, entities, markers));
+        match T::load(entity, data.components, storages, ids) {
+            Ok(()) => Ok(()),
+            Err(err) => Err(de::Error::custom(err))
+        }
+    }
+}
+
+/// Wrapper for `Entities` and tuple of `WriteStorage`s that implements `serde::de::Visitor`
+struct VisitEntities<'a, 'b: 'a, M: Marker, E, T: Components<M::Identifier, E>> {
+    entities: &'a Entities<'b>,
+    storages: &'a mut <T as Storages<'b>>::WriteStorages,
+    markers: &'a mut WriteStorage<'b, M>,
+    allocator: &'a mut FetchMut<'b, M::Allocator>,
+    pd: PhantomData<(M, E, T)>,
+}
+
+impl<'de, 'a, 'b: 'a, M, E, T> Visitor<'de> for VisitEntities<'a, 'b, M, E, T>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+{
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "Sequence of serialized entities")
+    }
+
+    fn visit_seq<A>(mut self, mut seq: A) -> Result<(), A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while seq.next_element_seed(DeserializeEntity {
+            entities: self.entities,
+            storages: self.storages,
+            markers: self.markers,
+            allocator: self.allocator,
+            pd: self.pd,
+        })?.is_some() {}
+
+        Ok(())
+    }
+}
+
+
+/// Deserialize entities
+pub fn deserialize<'a, 'de, D, M, E, T>(
+    entities: &Entities<'a>,
+    storages: &mut <T as Storages<'a>>::WriteStorages,
+    markers: &mut WriteStorage<'a, M>,
+    allocator: &mut FetchMut<'a, M::Allocator>,
+    deserializer: D,
+) -> Result<(), D::Error>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_seq(VisitEntities::<M, E, T> {
+        entities,
+        storages,
+        markers,
+        allocator,
+        pd: PhantomData,
+    })
+}
+
+
+/// `DeerializeSeed` implementation for `World`
+#[derive(SystemData)]
+pub struct WorldDeserialize<'a, M: Marker, E, T: Components<M::Identifier, E>> {
+    entities: Entities<'a>,
+    storages: <T as Storages<'a>>::WriteStorages,
+    markers: WriteStorage<'a, M>,
+    allocator: FetchMut<'a, M::Allocator>,
+    pd: PhantomData<E>,
+}
+
+impl<'de, 'a, M, E, T> DeserializeSeed<'de> for WorldDeserialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+{
+    type Value = ();
+
+    fn deserialize<D>(mut self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize::<D, M, E, T>(
+            &mut self.entities,
+            &mut self.storages,
+            &mut self.markers,
+            &mut self.allocator,
+            deserializer,
+        )
+    }
+}

--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -16,7 +16,7 @@ struct DeserializeEntity<'a, 'b: 'a, M: Marker, E, T: Components<M::Identifier, 
     storages: &'a mut <T as Storages<'b>>::WriteStorages,
     markers: &'a mut WriteStorage<'b, M>,
     allocator: &'a mut FetchMut<'b, M::Allocator>,
-    pd: PhantomData<(M, E, T)>,
+    pd: PhantomData<(E, T)>,
 }
 
 impl<'de, 'a, 'b: 'a, M, E, T> DeserializeSeed<'de> for DeserializeEntity<'a, 'b, M, E, T>
@@ -58,7 +58,7 @@ struct VisitEntities<'a, 'b: 'a, M: Marker, E, T: Components<M::Identifier, E>> 
     storages: &'a mut <T as Storages<'b>>::WriteStorages,
     markers: &'a mut WriteStorage<'b, M>,
     allocator: &'a mut FetchMut<'b, M::Allocator>,
-    pd: PhantomData<(M, E, T)>,
+    pd: PhantomData<(E, T)>,
 }
 
 impl<'de, 'a, 'b: 'a, M, E, T> Visitor<'de> for VisitEntities<'a, 'b, M, E, T>

--- a/src/saveload/details.rs
+++ b/src/saveload/details.rs
@@ -5,8 +5,8 @@ use serde::ser::Serialize;
 
 use {Component, Entity, ReadStorage, SystemData, WriteStorage};
 
-use saveload::marker::Marker;
 use error::NoError;
+use saveload::marker::Marker;
 
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]

--- a/src/saveload/details.rs
+++ b/src/saveload/details.rs
@@ -142,8 +142,10 @@ macro_rules! impl_components {
         impl_components!(@ $($a|$b),*);
     };
 
+    // List depleted. End of recursion
     (@) => {};
 
+    // Cut head of the list and call macro again
     (@ $ah:ident|$bh:ident $(,$a:ident|$b:ident)*) => {
         // Call again for tail
         impl_components!($($a|$b),*);

--- a/src/saveload/details.rs
+++ b/src/saveload/details.rs
@@ -1,0 +1,169 @@
+use std::error::Error;
+
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+
+use {Component, Entity, ReadStorage, SystemData, WriteStorage};
+
+use saveload::marker::Marker;
+use error::NoError;
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct EntityData<M: Marker, E, T: Components<M::Identifier, E>> {
+    pub marker: M,
+    pub components: T::Data,
+}
+
+/// This trait should be implemented in order to allow component
+/// to be serializeble with `SerializeSystem`.
+/// It is automatically implemented for all
+/// `Component + DeserializeOwned + Serialize + Copy`
+pub trait SaveLoadComponent<M>: Component {
+    /// Serializable data representation for component
+    type Data: Serialize + DeserializeOwned;
+
+    /// Error may occur duing serialization or deserialization of component
+    type Error: Error;
+
+    /// Convert this component into serializable form (`Data`) using
+    /// entity to marker mapping function
+    fn save<F>(&self, ids: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>;
+
+    /// Convert this component into deserializable form (`Data`) using
+    /// marker to entity mapping function
+    fn load<F>(data: Self::Data, ids: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>;
+}
+
+impl<C, M> SaveLoadComponent<M> for C
+where
+    C: Component + DeserializeOwned + Serialize + Copy,
+{
+    type Data = Self;
+    type Error = NoError;
+
+    fn save<F>(&self, _ids: F) -> Result<Self::Data, NoError> {
+        Ok(*self)
+    }
+
+    fn load<F>(data: Self, _ids: F) -> Result<Self, NoError> {
+        Ok(data)
+    }
+}
+
+/// Helper trait defines storages tuples for components tuple
+pub trait Storages<'a> {
+    /// Storages for read
+    type ReadStorages: SystemData<'a> + 'a;
+    /// Storages for write
+    type WriteStorages: SystemData<'a> + 'a;
+}
+
+/// This trait is implemented by any tuple where all elements are
+/// `Component + Serialize + DeserializeOwned`
+pub trait Components<M, E>: for<'a> Storages<'a> {
+    /// Serializable and deserializable intermediate representation
+    type Data: Serialize + DeserializeOwned;
+
+    /// Saves `Component`s of entity into `Data` serializable representation
+    fn save<'a, F>(
+        entity: Entity,
+        storages: &<Self as Storages<'a>>::ReadStorages,
+        ids: F,
+    ) -> Result<Self::Data, E>
+    where
+        F: FnMut(Entity) -> Option<M>;
+
+    /// Loads `Component`s to entity from `Data` deserializable representation
+    fn load<'a, F>(
+        entity: Entity,
+        components: Self::Data,
+        storages: &mut <Self as Storages<'a>>::WriteStorages,
+        ids: F,
+    ) -> Result<(), E>
+    where
+        F: FnMut(M) -> Option<Entity>;
+}
+
+macro_rules! impl_components {
+    ($($a:ident|$b:ident),*) => {
+        impl<'a, $($a),*> Storages<'a> for ($($a,)*)
+            where $(
+                $a: Component,
+            )*
+        {
+            type ReadStorages = ($(ReadStorage<'a, $a>,)*);
+            type WriteStorages = ($(WriteStorage<'a, $a>,)*);
+        }
+
+        impl<M, E $(,$a)*> Components<M, E> for ($($a,)*)
+            where $(
+                $a: SaveLoadComponent<M>,
+                E: From<$a::Error>,
+            )*
+        {
+            type Data = ($(Option<$a::Data>,)*);
+
+            #[allow(unused_variables, unused_mut, non_snake_case)]
+            fn save<'a, F>(entity: Entity, storages: &($(ReadStorage<'a, $a>,)*), mut ids: F)
+                -> Result<($(Option<$a::Data>,)*), E>
+                where F: FnMut(Entity) -> Option<M>
+            {
+                let ($(ref $b,)*) = *storages;
+                Ok(($(
+                    $b.get(entity).map(|c| c.save(&mut ids).map(Some)).unwrap_or(Ok(None))?,
+                )*))
+            }
+
+            #[allow(unused_variables, unused_mut, non_snake_case)]
+            fn load<'a, F>(entity: Entity, components: ($(Option<$a::Data>,)*),
+                           storages: &mut ($(WriteStorage<'a, $a>,)*), mut ids: F)
+                -> Result<(), E>
+                where F: FnMut(M) -> Option<Entity>
+            {
+                let ($($a,)*) = components;
+                let ($(ref mut $b,)*) = *storages;
+                $(
+                    if let Some(a) = $a {
+                        $b.insert(entity, $a::load(a, &mut ids)?);
+                    } else {
+                        $b.remove(entity);
+                    }
+                )*
+                Ok(())
+            }
+        }
+
+        // Recursivly implement for smaller tuple
+        impl_components!(@ $($a|$b),*);
+    };
+
+    (@) => {};
+
+    (@ $ah:ident|$bh:ident $(,$a:ident|$b:ident)*) => {
+        // Call again for tail
+        impl_components!($($a|$b),*);
+    };
+}
+
+impl_components!(
+    LA | LB,
+    MA | MB,
+    NA | NB,
+    OA | OB,
+    PA | PB,
+    QA | QB,
+    RA | RB,
+    SA | SB,
+    TA | TB,
+    UA | UB,
+    VA | VB,
+    WA | WB,
+    XA | XB,
+    YA | YB,
+    ZA | ZB
+);

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -20,11 +20,11 @@ use serde::de::DeserializeOwned;
 ///
 /// ```rust,no_run
 /// extern crate specs;
-/// #[macro_use] extern crate serde_derive;
+/// #[macro_use] extern crate serde;
 /// use std::collections::HashMap;
 /// use std::ops::Range;
 /// use specs::{Component, Entity, DenseVecStorage};
-/// use specs::saveload::marker::{Marker, MarkerAllocator};
+/// use specs::saveload::{Marker, MarkerAllocator};
 ///
 /// // Marker for entities that should be synced over network
 /// #[derive(Clone, Copy, Serialize, Deserialize)]

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -11,10 +11,10 @@ use serde::ser::Serialize;
 use serde::de::DeserializeOwned;
 
 
-/// This trait should be implemetened by component which is gonna be used as marker.
+/// This trait should be implemetened by a component which is going to be used as marker.
 /// This marker should be set to entity that should be serialized.
-/// If serialization strategy needs to set marker to some entity it should use
-/// new marker allocated for `Marker::Allocator`.
+/// If serialization strategy needs to set marker to some entity
+/// then it should use newly allocated marker from `Marker::Allocator`.
 ///
 /// ## Example
 ///
@@ -91,35 +91,35 @@ pub trait Marker: Component + DeserializeOwned + Serialize + Copy {
     fn id(&self) -> Self::Identifier;
 
     /// Update marker with new value.
-    /// It must preserve internal `Identifier`.
+    /// It must preserve the internal `Identifier`.
     ///
     /// ## Panics
     ///
     /// Allowed to panic if `self.id() != update.id()`.
-    /// But usually implementer may ignore `update.id()` value
+    /// But usually implementer may ignore the value of the `update.id()`
     /// as deserialization algorithm ensures `id()`s match.
     fn update(&mut self, update: Self) {
         ::std::mem::drop(update);
     }
 }
 
-/// This allocator is used with `Marker` trait.
-/// It provides method for allocation of `Marker`s.
-/// And also should provide `Marker -> Entity` mapping
-/// `maintain` method can be implemented for cleanup and actualization.
-/// See docs for `Marker` for example.
+/// This allocator is used with the `Marker` trait.
+/// It provides method for allocation new `Marker`s.
+/// It should also provide a `Marker -> Entity` mapping.
+/// The `maintain` method can be implemented for cleanup and actualization.
+/// See docs for `Marker` for an example.
 pub trait MarkerAllocator<M: Marker>: Resource {
     /// Allocate new `Marker`.
     /// Stores mapping `Marker` -> `Entity`.
-    /// If _id_ argument is `Some(id)` then new marker will have this `id`.
-    /// Otherwise allocator creates marker with new unique id.
+    /// If _id_ argument is `Some(id)` then the new marker will have this `id`.
+    /// Otherwise allocator creates marker with a new unique id.
     fn allocate(&mut self, entity: Entity, id: Option<M::Identifier>) -> M;
 
     /// Get `Entity` by `Marker::Identifier`
     fn get(&self, id: M::Identifier) -> Option<Entity>;
 
     /// Create new unique marker `M` and attach it to entity.
-    /// Or get old marker if already marked.
+    /// Or get old marker if this entity is already marked.
     fn mark<'a>(&mut self, entity: Entity, storage: &mut WriteStorage<'a, M>) -> M {
         match storage.get(entity).cloned() {
             Some(marker) => marker,
@@ -131,7 +131,8 @@ pub trait MarkerAllocator<M: Marker>: Resource {
         }
     }
 
-    /// Find `Entity` by `Marker` with same id and update `Marker` attached instance.
+    /// Find an `Entity` by a `Marker` with same id
+    /// and update `Marker` attached to the instance.
     /// Or create new entity and mark it.
     fn get_marked<'a>(
         &mut self,

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -1,0 +1,213 @@
+//! Provides `Marker` and `MarkerAllocator` traits
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use shred::Resource;
+use {Component, DenseVecStorage, Entities, Entity, Join, ReadStorage, WriteStorage};
+
+use serde::ser::Serialize;
+use serde::de::DeserializeOwned;
+
+
+/// This trait should be implemetened by component which is gonna be used as marker.
+/// This marker should be set to entity that should be serialized.
+/// If serialization strategy needs to set marker to some entity it should use
+/// new marker allocated for `Marker::Allocator`.
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// extern crate specs;
+/// #[macro_use] extern crate serde_derive;
+/// use std::collections::HashMap;
+/// use std::ops::Range;
+/// use specs::{Component, Entity, DenseVecStorage};
+/// use specs::saveload::marker::{Marker, MarkerAllocator};
+///
+/// // Marker for entities that should be synced over network
+/// #[derive(Clone, Copy, Serialize, Deserialize)]
+/// struct NetMarker {
+///     id: u64,
+///     seq: u64,
+/// }
+///
+/// impl Component for NetMarker {
+///     type Storage = DenseVecStorage<Self>;
+/// }
+///
+/// impl Marker for NetMarker {
+///     type Identifier = u64;
+///     type Allocator = NetNode;
+///
+///     fn id(&self) -> u64 {
+///         self.id
+///     }
+///
+///     // Updates sequence id.
+///     // Entities with too old sequence id get deleted.
+///     fn update(&mut self, update: Self) {
+///         assert_eq!(self.id, update.id);
+///         self.seq = update.seq;
+///     }
+/// }
+///
+/// // Each client and server has one
+/// // Contains id range and `NetMarker -> Entity` mapping
+/// struct NetNode {
+///     range: Range<u64>,
+///     mapping: HashMap<u64, Entity>,
+/// }
+///
+/// impl MarkerAllocator<NetMarker> for NetNode {
+///     fn allocate(&mut self, entity: Entity, id: Option<u64>) -> NetMarker {
+///         let id = id.unwrap_or_else(|| {
+///             self.range.next().expect("Id range must be virtually endless")
+///         });
+///         let marker = NetMarker {
+///             id: id,
+///             seq: 0,
+///         };
+///         self.mapping.insert(id, entity);
+///         marker
+///     }
+///
+///     fn get(&self, id: u64) -> Option<Entity> {
+///         self.mapping.get(&id).cloned()
+///     }
+/// }
+///
+/// fn main() {}
+/// ```
+pub trait Marker: Component + DeserializeOwned + Serialize + Copy {
+    /// Id of the marker
+    type Identifier: Copy + Debug + Eq + Hash;
+
+    /// Allocator for this `Marker`
+    type Allocator: MarkerAllocator<Self>;
+
+    /// Get this marker internal id
+    fn id(&self) -> Self::Identifier;
+
+    /// Update marker with new value.
+    /// It must preserve internal `Identifier`.
+    ///
+    /// ## Panics
+    ///
+    /// Allowed to panic if `self.id() != update.id()`.
+    /// But usually implementer may ignore `update.id()` value
+    /// as deserialization algorithm ensures `id()`s match.
+    fn update(&mut self, update: Self) {
+        ::std::mem::drop(update);
+    }
+}
+
+/// This allocator is used with `Marker` trait.
+/// It provides method for allocation of `Marker`s.
+/// And also should provide `Marker -> Entity` mapping
+/// `maintain` method can be implemented for cleanup and actualization.
+/// See docs for `Marker` for example.
+pub trait MarkerAllocator<M: Marker>: Resource {
+    /// Allocate new `Marker`.
+    /// Stores mapping `Marker` -> `Entity`.
+    /// If _id_ argument is `Some(id)` then new marker will have this `id`.
+    /// Otherwise allocator creates marker with new unique id.
+    fn allocate(&mut self, entity: Entity, id: Option<M::Identifier>) -> M;
+
+    /// Get `Entity` by `Marker::Identifier`
+    fn get(&self, id: M::Identifier) -> Option<Entity>;
+
+    /// Create new unique marker `M` and attach it to entity.
+    /// Or get old marker if already marked.
+    fn mark<'a>(&mut self, entity: Entity, storage: &mut WriteStorage<'a, M>) -> M {
+        match storage.get(entity).cloned() {
+            Some(marker) => marker,
+            None => {
+                let marker = self.allocate(entity, None);
+                storage.insert(entity, marker);
+                marker
+            }
+        }
+    }
+
+    /// Find `Entity` by `Marker` with same id and update `Marker` attached instance.
+    /// Or create new entity and mark it.
+    fn get_marked<'a>(
+        &mut self,
+        id: M::Identifier,
+        entities: &Entities<'a>,
+        storage: &mut WriteStorage<'a, M>,
+    ) -> Entity {
+        if let Some(entity) = self.get(id) {
+            if entities.is_alive(entity) {
+                return entity;
+            }
+        }
+
+        let entity = entities.create();
+        let marker = self.allocate(entity, Some(id));
+        storage.insert(entity, marker);
+        entity
+    }
+
+    /// Maintain internal data. Cleanup if necessary.
+    fn maintain<'a>(&mut self, _entities: &Entities<'a>, _storage: &ReadStorage<'a, M>) {}
+}
+
+/// Basic marker implementation usable for saving and loading
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct U64Marker(pub u64);
+impl Component for U64Marker {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Marker for U64Marker {
+    type Identifier = u64;
+    type Allocator = U64MarkerAllocator;
+    fn id(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Basic marker allocator
+#[derive(Clone, Debug)]
+pub struct U64MarkerAllocator {
+    index: u64,
+    mapping: HashMap<u64, Entity>,
+}
+
+impl U64MarkerAllocator {
+    /// Create new `U64MarkerAllocator` which will yield `U64Marker`s starting with `0`
+    pub fn new() -> Self {
+        U64MarkerAllocator {
+            index: 0,
+            mapping: HashMap::new(),
+        }
+    }
+}
+
+impl MarkerAllocator<U64Marker> for U64MarkerAllocator {
+    fn allocate(&mut self, entity: Entity, id: Option<u64>) -> U64Marker {
+        let marker = if let Some(id) = id {
+            U64Marker(id)
+        } else {
+            self.index += 1;
+            U64Marker(self.index - 1)
+        };
+        self.mapping.insert(marker.id(), entity);
+        marker
+    }
+
+    fn get(&self, id: u64) -> Option<Entity> {
+        self.mapping.get(&id).cloned()
+    }
+
+    fn maintain<'a>(&mut self, entities: &Entities<'a>, storage: &ReadStorage<'a, U64Marker>) {
+        // FIXME: may be too slow
+        self.mapping = (&**entities, storage)
+            .join()
+            .map(|(e, m)| (m.id(), e))
+            .collect();
+    }
+}

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -1,0 +1,13 @@
+//! Save and load entites from various formats with serde
+
+mod de;
+mod details;
+mod marker;
+mod ser;
+
+use self::details::{Components, EntityData, Storages};
+
+pub use self::de::{deserialize, WorldDeserialize};
+pub use self::details::SaveLoadComponent;
+pub use self::marker::{Marker, MarkerAllocator, U64Marker, U64MarkerAllocator};
+pub use self::ser::{serialize, serialize_recursive, WorldSerialize};

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -11,7 +11,8 @@ use saveload::marker::{Marker, MarkerAllocator};
 /// Serialize components from specified storages via `SerializableComponent::save`
 /// of all marked entities with provided serializer.
 /// When the component gets serialized with `SerializableComponent::save` method
-/// closure passed in `ids` argument mark unmarked `Entity` and they get serialized recursively.
+/// the closure passed in `ids` argument marks unmarked `Entity` (the marker of which was requested)
+/// and it will get serialized recursively.
 /// For serializing without such recursion see `serialize` function.
 pub fn serialize_recursive<'a, M, E, T, S>(
     entities: &Entities<'a>,
@@ -60,10 +61,10 @@ where
 /// Serialize components from specified storages via `SerializableComponent::save`
 /// of all marked entities with provided serializer.
 /// When the component gets serialized with `SerializableComponent::save` method
-/// closure passed in `ids` arguemnt returns `None` for unmarked `Entity`.
+/// the closure passed in `ids` arguemnt returns `None` for unmarked `Entity`.
 /// In this case `SerializableComponent::save` may perform workaround (forget about `Entity`)
 /// or fail.
-/// So function doesn't recursively mark referenced entities.
+/// So the function doesn't recursively mark referenced entities.
 /// For recursive marking see `serialize_recursive`
 pub fn serialize<'a, M, E, T, S>(
     entities: &Entities<'a>,
@@ -89,9 +90,9 @@ where
 }
 
 /// This type implements `Serialize` so that it may be used in generic environment
-/// where `Serialize` implementer is expected.
+/// where `Serialize` implementation is expected.
 /// It may be constructed manually with `WorldSerialize::new`.
-/// Or fetched by `System` as `SystemData`.
+/// Or fetched from `System` as `SystemData`.
 /// Serializes components in tuple `T` with marker `M`.
 #[derive(SystemData)]
 pub struct WorldSerialize<'a, M: Marker, E, T: Components<M::Identifier, E>> {
@@ -143,7 +144,7 @@ where
     T: Components<M::Identifier, E>,
 {
     /// Remove all marked entities
-    /// Use it if you want to delete entities that was just serialized
+    /// Use this if you want to delete entities that were just serialized
     pub fn remove_serialized(&mut self) {
         for (entity, _) in (&*self.entities, &self.markers.check()).join() {
             let _ = self.entities.delete(entity);

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -36,19 +36,18 @@ where
         let mut add = vec![];
         {
             let mut ids = |entity| -> Option<M::Identifier> {
-                match markers.get(entity).cloned() {
-                    Some(marker) => Some(marker.id()),
-                    None => {
-                        let marker = allocator.mark(entity, markers);
-                        add.push((entity, marker));
-                        Some(marker.id())
-                    }
+                let (marker, added) = allocator.mark(entity, markers);
+                if added {
+                    add.push((entity, marker));
                 }
+                Some(marker.id())
             };
             for (entity, marker) in to_serialize {
                 serseq.serialize_element(&EntityData::<M, E, T> {
                     marker,
-                    components: T::save(entity, storages, &mut ids).map_err(ser::Error::custom)?,
+                    components: T::save(entity, storages, &mut ids).map_err(
+                        ser::Error::custom,
+                    )?,
                 })?;
             }
         }
@@ -136,7 +135,7 @@ macro_rules! world_serialize_new_functions {
     };
 }
 
-world_serialize_new_functions!(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O);
+world_serialize_new_functions!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
 
 impl<'a, M, E, T> WorldSerialize<'a, M, E, T>
 where

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -1,0 +1,166 @@
+use std::fmt::Display;
+use std::marker::PhantomData;
+
+use serde::ser::{self, Serialize, SerializeSeq, Serializer};
+
+use {Entities, FetchMut, Join, ReadStorage, WriteStorage};
+
+use saveload::{Components, EntityData, Storages};
+use saveload::marker::{Marker, MarkerAllocator};
+
+/// Serialize components from specified storages via `SerializableComponent::save`
+/// of all marked entities with provided serializer.
+/// When the component gets serialized with `SerializableComponent::save` method
+/// closure passed in `ids` argument mark unmarked `Entity` and they get serialized recursively.
+/// For serializing without such recursion see `serialize` function.
+pub fn serialize_recursive<'a, M, E, T, S>(
+    entities: &Entities<'a>,
+    storages: &<T as Storages<'a>>::ReadStorages,
+    markers: &mut WriteStorage<'a, M>,
+    allocator: &mut FetchMut<'a, M::Allocator>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+    S: Serializer,
+{
+    let mut serseq = serializer.serialize_seq(None)?;
+    let mut to_serialize = (&**entities, &*markers)
+        .join()
+        .map(|(e, m)| (e, *m))
+        .collect::<Vec<_>>();
+    while !to_serialize.is_empty() {
+        let mut add = vec![];
+        {
+            let mut ids = |entity| -> Option<M::Identifier> {
+                match markers.get(entity).cloned() {
+                    Some(marker) => Some(marker.id()),
+                    None => {
+                        let marker = allocator.mark(entity, markers);
+                        add.push((entity, marker));
+                        Some(marker.id())
+                    }
+                }
+            };
+            for (entity, marker) in to_serialize {
+                serseq.serialize_element(&EntityData::<M, E, T> {
+                    marker,
+                    components: T::save(entity, storages, &mut ids).map_err(ser::Error::custom)?,
+                })?;
+            }
+        }
+        to_serialize = add;
+    }
+    serseq.end()
+}
+
+
+/// Serialize components from specified storages via `SerializableComponent::save`
+/// of all marked entities with provided serializer.
+/// When the component gets serialized with `SerializableComponent::save` method
+/// closure passed in `ids` arguemnt returns `None` for unmarked `Entity`.
+/// In this case `SerializableComponent::save` may perform workaround (forget about `Entity`)
+/// or fail.
+/// So function doesn't recursively mark referenced entities.
+/// For recursive marking see `serialize_recursive`
+pub fn serialize<'a, M, E, T, S>(
+    entities: &Entities<'a>,
+    storages: &<T as Storages<'a>>::ReadStorages,
+    markers: &ReadStorage<'a, M>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+    S: Serializer,
+{
+    let mut serseq = serializer.serialize_seq(None)?;
+    let ids = |entity| -> Option<M::Identifier> { markers.get(entity).map(Marker::id) };
+    for (entity, marker) in (&**entities, &*markers).join() {
+        serseq.serialize_element(&EntityData::<M, E, T> {
+            marker: *marker,
+            components: T::save(entity, storages, &ids).map_err(ser::Error::custom)?,
+        })?;
+    }
+    serseq.end()
+}
+
+/// This type implements `Serialize` so that it may be used in generic environment
+/// where `Serialize` implementer is expected.
+/// It may be constructed manually with `WorldSerialize::new`.
+/// Or fetched by `System` as `SystemData`.
+/// Serializes components in tuple `T` with marker `M`.
+#[derive(SystemData)]
+pub struct WorldSerialize<'a, M: Marker, E, T: Components<M::Identifier, E>> {
+    entities: Entities<'a>,
+    storages: <T as Storages<'a>>::ReadStorages,
+    markers: ReadStorage<'a, M>,
+    pd: PhantomData<E>,
+}
+
+macro_rules! world_serialize_new_functions {
+    ($($a:ident),*) => {
+        impl<'a, X, Z $(,$a)*> WorldSerialize<'a, X, Z, ($($a,)*)>
+            where X: Marker,
+                $(
+                    $a: super::SaveLoadComponent<X::Identifier>,
+                    Z: From<$a::Error>,
+                )*
+        {
+            /// Create serializable structure from storages
+            #[allow(non_snake_case)]
+            pub fn new(entities: Entities<'a>,
+                       markers: ReadStorage<'a, X>
+                       $(,$a: ReadStorage<'a, $a>)*) -> Self
+            {
+                WorldSerialize {
+                    entities,
+                    storages: ($($a,)*),
+                    markers,
+                    pd: PhantomData,
+                }
+            }
+        }
+
+        world_serialize_new_functions!(@ $($a),*);
+    };
+
+    (@) => {};
+    (@ $ah:ident $(,$a:ident)*) => {
+        // Call again for tail
+        world_serialize_new_functions!($($a),*);
+    };
+}
+
+world_serialize_new_functions!(A,B,C,D,E,F,G,H,I,J,K,L,M,N,O);
+
+impl<'a, M, E, T> WorldSerialize<'a, M, E, T>
+where
+    M: Marker,
+    T: Components<M::Identifier, E>,
+{
+    /// Remove all marked entities
+    /// Use it if you want to delete entities that was just serialized
+    pub fn remove_serialized(&mut self) {
+        for (entity, _) in (&*self.entities, &self.markers.check()).join() {
+            let _ = self.entities.delete(entity);
+        }
+    }
+}
+
+impl<'a, M, E, T> Serialize for WorldSerialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Display,
+    T: Components<M::Identifier, E>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize::<M, E, T, S>(&self.entities, &self.storages, &self.markers, serializer)
+    }
+}


### PR DESCRIPTION
Add (de)serialization support for entities to specs.
Main parts are:
* `Marker` trait.
`Marker` is used for several purposes:
  * Mark which entities should be serialized.
  * It contains ID to replace `Entity` stored in `Component`s during serialization process.
  * It may contain additional data to be used for tracking owner of the component.
* `MarkerAllocator` trait for allocating `Marker`s, storing `Marker -> Entity` mapping and other stuff.
* `SerializableComponent` trait that is auto implemented by components if they implements `Serialize`, `DeserializeOwned` and `Copy` (later is rather strict, maybe it should be replaced with `Clone` or removed somehow).
Mainly `Component` implements `SerializableComponent` manually when it contains `Entity`.
`Component` should replace `Entity` with provided `Marker` in `SerializableComponent::save` function. And replace `Marker` with `Entity` in `SerializableComponent::load` function.
* `Components` trait is implemented for tuples of `SerializableComponent`s
It allows to save all existing and mentioned in tuple components of one entity from `ReadStorage`s into serializable structure. And load it into `WriteStorage`s again.

Helper types `WorldSerialize` and `WorldDeserialize` are good example how to use this facility.