### PR TITLE
Use new version of shred and add example with `AsyncDispatcher`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ derivative = "1"
 fnv = "1.0"
 hibitset = "0.3.0"
 mopa = "0.2"
-shred = "0.4.6"
+shred = "0.5.0"
 shred-derive = "0.3"
 tuple_utils = "0.2"
 rayon = "0.8.2"
@@ -52,6 +52,9 @@ serialize = ["serde", "serde_derive"]
 cgmath =  { version = "0.14", features = ["eders"] }
 rand = "0.3"
 serde_json = "1.0"
+
+[[example]]
+name = "async"
 
 [[example]]
 name = "basic"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,0 +1,74 @@
+extern crate specs;
+
+use specs::{Component, DispatcherBuilder, Join, ReadStorage, System, VecStorage, World,
+            WriteStorage};
+
+// A component contains data which is associated with an entity.
+
+#[derive(Debug)]
+struct Vel(f32);
+
+impl Component for Vel {
+    type Storage = VecStorage<Self>;
+}
+
+#[derive(Debug)]
+struct Pos(f32);
+
+impl Component for Pos {
+    type Storage = VecStorage<Self>;
+}
+
+struct SysA;
+
+impl<'a> System<'a> for SysA {
+    // These are the resources required for execution.
+    // You can also define a struct and `#[derive(SystemData)]`,
+    // see the `full` example.
+    type SystemData = (WriteStorage<'a, Pos>, ReadStorage<'a, Vel>);
+
+    fn run(&mut self, (mut pos, vel): Self::SystemData) {
+        // The `.join()` combines multiple components,
+        // so we only access those entities which have
+        // both of them.
+        // You could also use `par_join()` to get a rayon `ParallelIterator`.
+        for (pos, vel) in (&mut pos, &vel).join() {
+            pos.0 += vel.0;
+        }
+    }
+}
+
+fn main() {
+    // The `World` is our
+    // container for components
+    // and other resources.
+
+    let mut world = World::new();
+    world.register::<Pos>();
+    world.register::<Vel>();
+
+    // An entity may or may not contain some component.
+
+    world.create_entity().with(Vel(2.0)).with(Pos(0.0)).build();
+    world.create_entity().with(Vel(4.0)).with(Pos(1.6)).build();
+    world.create_entity().with(Vel(1.5)).with(Pos(5.4)).build();
+
+    // This entity does not have `Vel`, so it won't be dispatched.
+    world.create_entity().with(Pos(2.0)).build();
+
+    // This builds an async dispatcher.
+    // The third parameter of `add` specifies
+    // logical dependencies on other systems.
+    // Since we only have one, we don't depend on anything.
+    // See the `full` example for dependencies.
+    let mut dispatcher = DispatcherBuilder::new()
+        .add(SysA, "sys_a", &[])
+        .build_async(world);
+
+    // This dispatches all the systems in parallel and async.
+    dispatcher.dispatch();
+
+    // Do something on the main thread
+
+    dispatcher.wait();
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam::sync::TreiberStack;
@@ -955,6 +956,12 @@ impl World {
 unsafe impl Send for World {}
 
 unsafe impl Sync for World {}
+
+impl Borrow<Resources> for World {
+    fn borrow(&self) -> &Resources {
+        &self.res
+    }
+}
 
 impl Component for World {
     type Storage = DenseVecStorage<Self>;


### PR DESCRIPTION
I know CI will fail for this, but it won't anymore as soon as merged onto staging by bors.

@kvark if you still want to rename the `serialize` feature, which seems to complicate the `Cargo.toml`, please release a new version after merging this PR and the feature name change. Otherwise, I think we can get 0.10 out after merging only this PR.