### PR TITLE
Replace let delta with let mut delta

### DIFF
--- a/book/src/04_resources.md
+++ b/book/src/04_resources.md
@@ -26,9 +26,10 @@ world.add_resource(DeltaTime(0.05)); // Let's use some start value
 To update the delta time, just use
 
 ```rust,ignore
-let delta = world.write_resource::<DeltaTime>();
+let mut delta = world.write_resource::<DeltaTime>();
 *delta = DeltaTime(0.04);
 ```
+
 ## Accessing resources from a system
 
 As you might have guessed, there's a type implementing system data


### PR DESCRIPTION
Sorry, the code was wrong. If you also want to dispatch you'll need to use a scope like so

```rust
let mut world = World::new();
world.add_resource(DeltaTime(0.04));

{
    let mut delta = world.write_resource::<DeltaTime>();
    delta.0 = 0.02;
    // The borrow ends here
}

dispatcher.dispatch(&mut world.res); // so we can borrow from world here again
```