### PR TITLE
Introduce nightly feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,11 @@ before_script:
 - export PATH="$PATH:$HOME/.cargo/bin"
 
 script:
-- cargo build --all-features --verbose
-- cargo test --all-features --verbose
+- cargo build --features="common,serde,rudy" --verbose
+- cargo test --features="common,serde,rudy" --verbose
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    cargo build --all-features --verbose;
+    cargo test --all-features --verbose;
     cargo bench --verbose --no-run --all-features;
   fi
 - cargo build --manifest-path ./specs-derive/Cargo.toml --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,10 @@ rudy = { version = "0.1", optional = true }
 
 [features]
 common = ["futures"]
+nightly = []
 
 [package.metadata.docs.rs]
-features = ["common", "serde"]
+features = ["common", "serde", "nightly"]
 
 [dev-dependencies]
 cgmath =  { version = "0.14", features = ["eders"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ common = ["futures"]
 nightly = []
 
 [package.metadata.docs.rs]
-features = ["common", "serde", "nightly"]
+features = ["common", "serde"]
 
 [dev-dependencies]
 cgmath =  { version = "0.14", features = ["eders"] }

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -188,9 +188,9 @@ impl<'a> System<'a> for Spawn {
             mut ball,
             mut rect,
             mut color,
-            mut requests
-        ): Self::SystemData
-){
+            mut requests,
+        ): Self::SystemData,
+    ) {
         use cgmath::Zero;
         use rand::Rng;
 

--- a/examples/saveload.rs
+++ b/examples/saveload.rs
@@ -5,8 +5,7 @@ extern crate specs;
 
 use specs::{Component, RunNow, System, VecStorage, World};
 use specs::error::NoError;
-use specs::saveload::{U64Marker, U64MarkerAllocator, WorldDeserialize,
-                      WorldSerialize};
+use specs::saveload::{U64Marker, U64MarkerAllocator, WorldDeserialize, WorldSerialize};
 
 const ENTITIES: &str = "
 [

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -9,8 +9,8 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
-use syn::{Ident, MacroInput, MetaItem, NestedMetaItem};
 use quote::Tokens;
+use syn::{Ident, MacroInput, MetaItem, NestedMetaItem};
 
 /// Custom derive macro for the `Component` trait.
 ///
@@ -41,7 +41,8 @@ fn impl_component(ast: &MacroInput) -> Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-    let storage = ast.attrs.first()
+    let storage = ast.attrs
+        .first()
         .and_then(|attr| match attr.value {
             MetaItem::List(ref ident, ref items) if ident == "component" => items.first(),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 
 //! # SPECS Parallel ECS
 //!

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -17,13 +17,15 @@ mod lazy;
 mod tests;
 
 #[cfg(not(feature = "nightly"))]
-/// Note: Enable nightly feature to get the component type
-/// printed instead of just a vague catch all message.
 const COMPONENT_NOT_REGISTERED: &str = "No component with the given id. Did you forget to register \
-                                        the component with `World::register::<ComponentName>()`?";
+                                        the component with `World::register::<ComponentName>()`? \
+                                        Note: Enable `nightly` feature to get the exact component \
+                                        type printed out.";
 #[cfg(not(feature = "nightly"))]
 const RESOURCE_NOT_ADDED: &str = "No resource with the given id. Did you forget to add \
-                                  the resource with `World::add_resource(resource)`?";
+                                  the resource with `World::add_resource(resource)`?
+                                  Note: Enable `nightly` feature to get the exact resource \
+                                  type printed out.";
 
 #[cfg(feature = "nightly")]
 fn nightly_component_message<T>(id: usize) -> String {


### PR DESCRIPTION
Adds a new feature flag `nightly` for unstable, but useful features.

Also adds first feature using the flag which allows clearer panic messages when not adding/registering resources/components.

Examples of new error message when enabled:
```
thread 'main' panicked at 'Component `Pos` was unregistered. Did you forget to register the component with `World::register::<Pos>()`', src\libcore\option.rs:839:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
error: process didn't exit successfully: `target\debug\examples\cluster_bomb.exe` (exit code: 101)
```
```
thread 'main' panicked at 'No resource `specs::saveload::U64MarkerAllocator` exists in the world. Did you forget to add the resource with `World::add_resource::<specs::saveload::U64MarkerAllocator>(...)`', src\libcore\option.rs:839:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
error: process didn't exit successfully: `target\debug\examples\saveload.exe` (exit code: 101)
```