### PR TITLE
Adds way of getting components of specific entity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "slide-rs/specs" }
 crossbeam = "0.3.0"
 derivative = "1"
 fnv = "1.0"
-hibitset = {git = "https://github.com/WaDelma/hibitset", branch = "contains"}#"0.2.0"
+hibitset = { git = "https://github.com/slide-rs/hibitset" }
 mopa = "0.2"
 shred = "0.5.0"
 shred-derive = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "slide-rs/specs" }
 crossbeam = "0.3.0"
 derivative = "1"
 fnv = "1.0"
-hibitset = "0.3.2"
+hibitset = {git = "https://github.com/WaDelma/hibitset", branch = "contains"}#"0.2.0"
 mopa = "0.2"
 shred = "0.5.0"
 shred-derive = "0.3"

--- a/src/join.rs
+++ b/src/join.rs
@@ -250,12 +250,15 @@ impl<J: Join> JoinIter<J> {
         }
     }
 
-    /// Allows getting joined values for specific entity.
+    /// Allows getting joined values for specific raw index.
     /// 
-    /// This method doesn't check if the entity is alive, so it should only be used if it actually is.
-    pub fn get_unchecked(&mut self, entity: Entity) -> Option<J::Type> {
-        if self.keys.contains(entity.id()) {
-            Some(unsafe { J::get(&mut self.values, entity.id()) })
+    /// The raw index for an `Entity` can be retrieved using `Entity::id` method.
+    ///
+    /// As this method operates on raw indices, there is no check to see if the entity is still alive,
+    /// so the caller should ensure it instead.
+    pub fn get_unchecked(&mut self, index: Index) -> Option<J::Type> {
+        if self.keys.contains(index) {
+            Some(unsafe { J::get(&mut self.values, index) })
         } else {
             None
         }

--- a/src/join.rs
+++ b/src/join.rs
@@ -7,7 +7,7 @@ use rayon::iter::internal::{bridge_unindexed, Folder, UnindexedConsumer, Unindex
 use tuple_utils::Split;
 
 use world::Entity;
-use Index;
+use {Index, Entities};
 
 /// `BitAnd` is a helper method to & bitsets together resulting in a tree.
 pub trait BitAnd {
@@ -194,9 +194,9 @@ impl<J: Join> JoinIter<J> {
 
 impl<J: Join> JoinIter<J> {
     /// Allows getting joined values for specific entity.
-    pub fn get(&mut self, e: Entity) -> Option<J::Type> {
-        if self.keys.contains(e.id()) {
-            Some(unsafe { J::get(&mut self.values, e.id()) })
+    pub fn get(&mut self, entity: Entity, entities: &Entities) -> Option<J::Type> {
+        if self.keys.contains(entity.id()) && entities.is_alive(entity) {
+            Some(unsafe { J::get(&mut self.values, entity.id()) })
         } else {
             None
         }

--- a/src/join.rs
+++ b/src/join.rs
@@ -6,6 +6,7 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::{bridge_unindexed, Folder, UnindexedConsumer, UnindexedProducer};
 use tuple_utils::Split;
 
+use world::Entity;
 use Index;
 
 /// `BitAnd` is a helper method to & bitsets together resulting in a tree.
@@ -187,6 +188,17 @@ impl<J: Join> JoinIter<J> {
         JoinIter {
             keys: keys.iter(),
             values,
+        }
+    }
+}
+
+impl<J: Join> JoinIter<J> {
+    /// Allows getting joined values for specific entity.
+    pub fn get(&mut self, e: Entity) -> Option<J::Type> {
+        if self.keys.contains(e.id()) {
+            Some(unsafe { J::get(&mut self.values, e.id()) })
+        } else {
+            None
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -484,7 +484,7 @@ fn getting_specific_entity_with_join() {
         );
         entity
     };
-    world.delete_entity(entity);
+    world.delete_entity(entity).unwrap();
     world.create_entity().with(CompInt(2)).with(CompBool(false)).build();
     let ints = world.read::<CompInt>();
     let mut bools = world.write::<CompBool>();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -468,17 +468,28 @@ fn getting_specific_entity_with_join() {
     let mut world = create_world();
     world.create_entity().with(CompInt(1)).with(CompBool(true)).build();
 
+    let entity = {
+        let ints = world.read::<CompInt>();
+        let mut bools = world.write::<CompBool>();
+        let entity = world.entities().join().next().unwrap();
+
+        assert_eq!(
+            Some((&CompInt(1), &mut CompBool(true))),
+            (&ints, &mut bools).join().get(entity, &world.entities())
+        );
+        bools.remove(entity);
+        assert_eq!(
+            None,
+            (&ints, &mut bools).join().get(entity, &world.entities())
+        );
+        entity
+    };
+    world.delete_entity(entity);
+    world.create_entity().with(CompInt(2)).with(CompBool(false)).build();
     let ints = world.read::<CompInt>();
     let mut bools = world.write::<CompBool>();
-    let entity = world.entities().join().next().unwrap();
-
-    assert_eq!(
-        Some((&CompInt(1), &mut CompBool(true))),
-        (&ints, &mut bools).join().get(entity)
-    );
-    bools.remove(entity);
     assert_eq!(
         None,
-        (&ints, &mut bools).join().get(entity)
+        (&ints, &mut bools).join().get(entity, &world.entities())
     );
 }


### PR DESCRIPTION
After randomly browsing through [rhusics](https://github.com/Rhuagh/rhusics) I noticed [piece of code](https://github.com/Rhuagh/rhusics/blob/259ff9e4ea61e98919472ea9ac77005177301c1d/src/ecs/collide/systems/spatial_collision.rs#L178) and thought about API that would make it cleaner/more efficient and this is the result.

The code in question after this PR:
```rust
let (left_shape, left_pose, left_next_pose) =
    (&shapes, &poses, &next_poses).join().get(left_entity).uwnrap();

let (right_shape, right_pose, right_next_pose) =
    (&shapes, &poses, &next_poses).join().get(right_entity).uwnrap();
```

Depends on slide-rs/hibitset#20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/299)
<!-- Reviewable:end -->
