### PR TITLE
Added more documentation to world read / write methods.

### DIFF
--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -379,7 +379,9 @@ impl World {
         self.write_with_id(0)
     }
 
-    /// Fetches a component's storage with a specified id for reading.
+    /// Fetches a component's storage with a specified component id for reading.
+    /// ID is for components registered with an ID, and does not correspond to
+    /// entity IDs. For basic setups, use an ID of 0 or use the read() function.
     ///
     /// ## Panics
     ///
@@ -393,6 +395,8 @@ impl World {
     }
 
     /// Fetches a component's storage with a specified id for writing.
+    /// ID is for components registered with an ID, and does not correspond to
+    /// entity IDs. For basic setups, use an ID of 0 or use the write() function.
     ///
     /// # Panics
     ///
@@ -406,6 +410,9 @@ impl World {
     }
 
     /// Fetches a resource with a specified id for reading.
+    /// ID is for resources registered with an ID, and does not correspond to
+    /// entity IDs. For basic setups, use an ID of 0 or use the read_resource()
+    /// function.
     ///
     /// ## Panics
     ///
@@ -416,6 +423,9 @@ impl World {
     }
 
     /// Fetches a resource with a specified id for writing.
+    /// ID is for resources registered with an ID, and does not correspond to
+    /// entity IDs. For basic setups, use an ID of 0 or use the write_resource()
+    /// function.
     ///
     /// ## Panics
     ///


### PR DESCRIPTION
Whilst there was already documentation explaining component / resource
IDs, it was easy to skim over and no reference was made by the
read_with_id and write_with_id methods. This made it seem like it
expected an entity ID to search for a component, whereas in reality it's
used for more complex component / resource setups.

This is meant to address #310 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/312)
<!-- Reviewable:end -->
