### PR TITLE
Add drop method to UnprotectedStorage trait.

### DIFF
--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use hibitset::BitSet;
+use hibitset::{BitSet, BitSetLike};
 
 use {Index, Join, UnprotectedStorage};
 use world::EntityIndex;
@@ -86,9 +86,9 @@ pub struct FlaggedStorage<C, T> {
 }
 
 impl<C, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedStorage<C, T> {
-    unsafe fn clean<F>(&mut self, has: F)
+    unsafe fn clean<B>(&mut self, has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
         self.mask.clear();
         self.storage.clean(has);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -496,8 +496,8 @@ where
 
 /// Used by the framework to quickly join components.
 pub trait UnprotectedStorage<T> {
-    /// Clean the storage given a check to figure out if an index
-    /// is valid or not. Allows us to safely drop the storage.
+    /// Clean the storage given a bitset with bits set for valid indices.
+    /// Allows us to safely drop the storage.
     unsafe fn clean<B>(&mut self, has: B)
     where
         B: BitSetLike;

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use fnv::FnvHashMap;
+use hibitset::BitSetLike;
 
 use {DistinctStorage, Index, UnprotectedStorage};
 
@@ -15,9 +16,9 @@ use rudy::rudymap::RudyMap;
 pub struct BTreeStorage<T>(BTreeMap<Index, T>);
 
 impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
-    unsafe fn clean<F>(&mut self, _: F)
+    unsafe fn clean<B>(&mut self, _has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
         // nothing to do
     }
@@ -47,9 +48,9 @@ unsafe impl<T> DistinctStorage for BTreeStorage<T> {}
 pub struct HashMapStorage<T>(FnvHashMap<Index, T>);
 
 impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
-    unsafe fn clean<F>(&mut self, _: F)
+    unsafe fn clean<B>(&mut self, _has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
         //nothing to do
     }
@@ -85,9 +86,9 @@ pub struct DenseVecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
-    unsafe fn clean<F>(&mut self, _: F)
+    unsafe fn clean<B>(&mut self, _has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
         // nothing to do
     }
@@ -130,9 +131,9 @@ unsafe impl<T> DistinctStorage for DenseVecStorage<T> {}
 pub struct NullStorage<T>(T);
 
 impl<T: Default> UnprotectedStorage<T> for NullStorage<T> {
-    unsafe fn clean<F>(&mut self, _: F)
+    unsafe fn clean<B>(&mut self, _has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
     }
 
@@ -174,13 +175,13 @@ unsafe impl<T> DistinctStorage for NullStorage<T> {}
 pub struct VecStorage<T>(Vec<T>);
 
 impl<T> UnprotectedStorage<T> for VecStorage<T> {
-    unsafe fn clean<F>(&mut self, has: F)
+    unsafe fn clean<B>(&mut self, has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
         use std::ptr;
         for (i, v) in self.0.iter_mut().enumerate() {
-            if has(i as Index) {
+            if has.contains(i as u32) {
                 ptr::drop_in_place(v);
             }
         }
@@ -226,9 +227,9 @@ pub struct RudyStorage<T>(RudyMap<Index, T>);
 
 #[cfg(feature = "rudy")]
 impl<T> UnprotectedStorage<T> for RudyStorage<T> {
-    unsafe fn clean<F>(&mut self, _: F)
+    unsafe fn clean<B>(&mut self, _has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
     }
 

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -370,12 +370,14 @@ mod test {
         struct A(Arc<()>);
 
         let mut storage = VecStorage::<A>::default();
+        let mut bitset = BitSet::new();
 
         unsafe {
             for i in (0..200).filter(|i| i % 2 != 0) {
                 storage.insert(i, A(Arc::new(())));
+                bitset.add(i);
             }
-            storage.clean(|i| i % 2 != 0);
+            storage.clean(&bitset);
         }
     }
 

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -3,7 +3,10 @@ use mopa::Any;
 use super::*;
 use {Component, Entity, Generation, Index, World};
 
-fn create<T: Component>(world: &mut World) -> WriteStorage<T> {
+fn create<T: Component>(world: &mut World) -> WriteStorage<T>
+where
+    T::Storage: Default,
+{
     world.register::<T>();
 
     world.write()
@@ -217,7 +220,10 @@ mod test {
         type Storage = NullStorage<Self>;
     }
 
-    fn test_add<T: Component + From<u32> + Debug + Eq>() {
+    fn test_add<T: Component + From<u32> + Debug + Eq>()
+    where
+        T::Storage: Default,
+    {
         let mut w = World::new();
         let mut s: Storage<T, _> = create(&mut w);
 
@@ -233,7 +239,10 @@ mod test {
         }
     }
 
-    fn test_sub<T: Component + From<u32> + Debug + Eq>() {
+    fn test_sub<T: Component + From<u32> + Debug + Eq>()
+    where
+        T::Storage: Default,
+    {
         let mut w = World::new();
         let mut s: Storage<T, _> = create(&mut w);
 
@@ -250,7 +259,10 @@ mod test {
         }
     }
 
-    fn test_get_mut<T: Component + From<u32> + AsMut<u32> + Debug + Eq>() {
+    fn test_get_mut<T: Component + From<u32> + AsMut<u32> + Debug + Eq>()
+    where
+        T::Storage: Default,
+    {
         let mut w = World::new();
         let mut s: Storage<T, _> = create(&mut w);
 
@@ -272,7 +284,10 @@ mod test {
         }
     }
 
-    fn test_add_gen<T: Component + From<u32> + Debug + Eq>() {
+    fn test_add_gen<T: Component + From<u32> + Debug + Eq>()
+    where
+        T::Storage: Default,
+    {
         let mut w = World::new();
         let mut s: Storage<T, _> = create(&mut w);
 
@@ -290,7 +305,10 @@ mod test {
         }
     }
 
-    fn test_sub_gen<T: Component + From<u32> + Debug + Eq>() {
+    fn test_sub_gen<T: Component + From<u32> + Debug + Eq>()
+    where
+        T::Storage: Default,
+    {
         let mut w = World::new();
         let mut s: Storage<T, _> = create(&mut w);
 
@@ -303,7 +321,10 @@ mod test {
         }
     }
 
-    fn test_clear<T: Component + From<u32>>() {
+    fn test_clear<T: Component + From<u32>>()
+    where
+        T::Storage: Default,
+    {
         let mut w = World::new();
         let mut s: Storage<T, _> = create(&mut w);
 
@@ -318,7 +339,10 @@ mod test {
         }
     }
 
-    fn test_anti<T: Component + From<u32> + Debug + Eq>() {
+    fn test_anti<T: Component + From<u32> + Debug + Eq>()
+    where
+        T::Storage: Default,
+    {
         use join::Join;
 
         let mut w = World::new();

--- a/src/storage/tracked.rs
+++ b/src/storage/tracked.rs
@@ -241,12 +241,12 @@ where
     C: Clone,
     S: UnprotectedStorage<C>,
 {
-    unsafe fn clean<F>(&mut self, f: F)
+    unsafe fn clean<B>(&mut self, has: B)
     where
-        F: Fn(Index) -> bool,
+        B: BitSetLike,
     {
-        self.old.clean(&f);
-        self.storage.clean(&f);
+        self.old.clean(&has);
+        self.storage.clean(&has);
     }
 
     unsafe fn get(&self, id: Index) -> &C {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -305,7 +305,10 @@ impl World {
     /// world.register::<Pos>();
     /// // Register all other components like this
     /// ```
-    pub fn register<T: Component>(&mut self) {
+    pub fn register<T: Component>(&mut self)
+    where
+        T::Storage: Default,
+    {
         self.register_with_id::<T>(0);
     }
 
@@ -313,7 +316,26 @@ impl World {
     ///
     /// Does nothing if the component was already
     /// registered.
-    pub fn register_with_id<T: Component>(&mut self, id: usize) {
+    pub fn register_with_id<T: Component>(&mut self, id: usize)
+    where
+        T::Storage: Default,
+    {
+        self.register_with_storage_and_id::<T>(id, T::Storage::default());
+    }
+
+    /// Registers a new component with a given storage.
+    ///
+    /// Does nothing if the component was already
+    /// registered.
+    pub fn register_with_storage<T: Component>(&mut self, storage: T::Storage) {
+        self.register_with_storage_and_id::<T>(0, storage);
+    }
+
+    /// Registers a new component with a given storage and id.
+    ///
+    /// Does nothing if the component was already
+    /// registered.
+    pub fn register_with_storage_and_id<T: Component>(&mut self, id: usize, storage: T::Storage) {
         use shred::ResourceId;
 
         if self.res
@@ -322,7 +344,7 @@ impl World {
             return;
         }
 
-        self.res.add_with_id(MaskedStorage::<T>::new(), id);
+        self.res.add_with_id(MaskedStorage::<T>::new(storage), id);
 
         let mut storage = self.res.fetch_mut::<MaskedStorage<T>>(id);
         self.storages.push(&mut *storage as *mut AnyStorage);
@@ -609,10 +631,7 @@ impl World {
     fn delete_components(&mut self, delete: &[Entity]) {
         for storage in &mut self.storages {
             let storage: &mut AnyStorage = unsafe { &mut **storage };
-
-            for entity in delete {
-                storage.remove(entity.id());
-            }
+            storage.drop(delete);
         }
     }
 


### PR DESCRIPTION
Default-implemented via remove.
Can be overridden for some special components (I'd use this in amethyst renderer).
`AnyStorage::remove` is replaced with `AnyStorage::drop` which doesn't return anything thus avoiding unnecessary boxing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/328)
<!-- Reviewable:end -->
