### PR TITLE
Reexport `Resources`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ extern crate shred_derive;
 extern crate rudy;
 
 pub use join::{Join, JoinIter, JoinParIter, ParJoin};
-pub use shred::{Dispatcher, DispatcherBuilder, Fetch, FetchId, FetchIdMut, FetchMut, RunNow,
+pub use shred::{Dispatcher, DispatcherBuilder, Fetch, FetchId, FetchIdMut, FetchMut, Resources, RunNow,
                 RunningTime, System, SystemData};
 
 #[cfg(not(target_os = "emscripten"))]


### PR DESCRIPTION
`Resources` should be reexported as it is the only thing that requires average user of `specs` to add `shred` as  direct dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/335)
<!-- Reviewable:end -->
