### PR TITLE
Tests, DistinctStorage bounds, narrower generics for better inference.

### DIFF
--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -86,6 +86,8 @@ where
 {
 }
 
+// For explanation of why `ImmutableParallelRestriction` instead of `RT: ImmutableAliasing`, see
+// the `Join` implementation of `RestrictedStorage`.
 unsafe impl<'rf, 'st: 'rf, B, T, R> ParJoin
     for &'rf RestrictedStorage<'rf, 'st, B, T, R, ImmutableParallelRestriction>
 where
@@ -166,6 +168,15 @@ where
     }
 }
 
+// This is actually fine for `SequentialRestriction` (or any restriction with
+// `ImmutableAliasing` as well, however Rust then requires differentiation
+// between the two. Since there is no reason to use `SequentialRestriction`
+// and only use it as an `ImmutableRestriction`, might as well improve ergonomics
+// for common-case calls.
+//
+// e.g.
+// With `ImmutableAliasing`: `(&mut storage.restrict_mut())`
+// With `ImmutableParallelRestriction`: `storage.restrict_mut()`
 impl<'rf, 'st: 'rf, B, T, R> Join for &'rf RestrictedStorage<'rf, 'st, B, T, R, ImmutableParallelRestriction>
 where
     T: Component,


### PR DESCRIPTION
Solves a soundness issue with `RestrictedStorage` that disallows storages that do not implement `DistinctStorage` to not be allowed to be run in parallel.

Adds some basic tests (mainly for compile time guarantees, but with a bit of sanity checking).

Adds `ImmutableParallelRestriction` as a concrete bound on the `Join`/`ParJoin` implementations of `&'a RestrictedStorage` so that Rust can infer `storage.restrict_mut().join()` to be a mutable restricted storage, instead of having to specify `(&mut storage.restrict_mut()).join()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/354)
<!-- Reviewable:end -->
