### PR TITLE
Rename world::read and world::write, re-export shred::Resources

### DIFF
--- a/benches/storage_cmp.rs
+++ b/benches/storage_cmp.rs
@@ -19,7 +19,7 @@ where
         },
         |world| {
             let entities = world.entities();
-            let mut storage = world.write::<C>();
+            let mut storage = world.write_storage::<C>();
 
             for e in entities.create_iter().take(num) {
                 storage.insert(e, C::default());
@@ -41,7 +41,7 @@ where
 
             {
                 let entities = world.entities();
-                let mut storage = world.write::<C>();
+                let mut storage = world.write_storage::<C>();
 
                 for e in entities.create_iter().take(num) {
                     storage.insert(e, C::default());
@@ -52,7 +52,7 @@ where
         },
         |world| {
             let entities = world.entities();
-            let mut storage = world.write::<C>();
+            let mut storage = world.write_storage::<C>();
 
             for e in (&*entities).join() {
                 storage.remove(e);
@@ -74,7 +74,7 @@ where
 
             {
                 let entities = world.entities();
-                let mut storage = world.write::<C>();
+                let mut storage = world.write_storage::<C>();
 
                 for e in entities.create_iter().take(num) {
                     storage.insert(e, C::default());
@@ -85,7 +85,7 @@ where
         },
         |world| {
             let entities = world.entities();
-            let storage = world.read::<C>();
+            let storage = world.read_storage::<C>();
 
             for e in (&*entities).join() {
                 black_box(storage.get(e));

--- a/benches/storage_sparse.rs
+++ b/benches/storage_sparse.rs
@@ -42,8 +42,8 @@ macro_rules! gap {
 
             fn insert(bencher: &mut Bencher) {
                 let (world, entities) = setup(true, false, $sparsity);
-                let mut ints = world.write::<CompInt>();
-                let mut bools = world.write::<CompBool>();
+                let mut ints = world.write_storage::<CompInt>();
+                let mut bools = world.write_storage::<CompBool>();
 
                 bencher.iter(move || {
                     for &entity in &entities {
@@ -55,8 +55,8 @@ macro_rules! gap {
 
             fn remove(bencher: &mut Bencher) {
                 let (world, entities) = setup(true, true, $sparsity);
-                let mut ints = world.write::<CompInt>();
-                let mut bools = world.write::<CompBool>();
+                let mut ints = world.write_storage::<CompInt>();
+                let mut bools = world.write_storage::<CompBool>();
 
                 bencher.iter(move || {
                     for &entity in &entities {
@@ -68,8 +68,8 @@ macro_rules! gap {
 
             fn get(bencher: &mut Bencher) {
                 let (world, entities) = setup(false, true, $sparsity);
-                let ints = world.read::<CompInt>();
-                let bools = world.read::<CompBool>();
+                let ints = world.read_storage::<CompInt>();
+                let bools = world.read_storage::<CompBool>();
 
                 bencher.iter(move || {
                     for &entity in &entities {

--- a/benches/world.rs
+++ b/benches/world.rs
@@ -142,14 +142,14 @@ fn join_single_threaded(b: &mut Bencher) {
 
     {
         let entities: Vec<_> = world.create_iter().take(50_000).collect();
-        let mut comp_int = world.write();
+        let mut comp_int = world.write_storage();
         for (i, e) in entities.iter().enumerate() {
             comp_int.insert(*e, CompInt(i as i32));
         }
     }
 
     b.iter(|| {
-        for comp in world.read::<CompInt>().join() {
+        for comp in world.read_storage::<CompInt>().join() {
             black_box(comp.0 * comp.0);
         }
     })
@@ -164,14 +164,14 @@ fn join_multi_threaded(b: &mut Bencher) {
 
     {
         let entities: Vec<_> = world.create_iter().take(50_000).collect();
-        let mut comp_int = world.write();
+        let mut comp_int = world.write_storage();
         for (i, e) in entities.iter().enumerate() {
             comp_int.insert(*e, CompInt(i as i32));
         }
     }
 
     b.iter(|| {
-        world.read::<CompInt>().par_join().for_each(|comp| {
+        world.read_storage::<CompInt>().par_join().for_each(|comp| {
             black_box(comp.0 * comp.0);
         })
     })

--- a/examples/cluster_bomb.rs
+++ b/examples/cluster_bomb.rs
@@ -136,7 +136,7 @@ fn main() {
         let mut entities = 0;
         {
             // Simple console rendering
-            let positions = world.read::<Pos>();
+            let positions = world.read_storage::<Pos>();
             const WIDTH: usize = 10;
             const HEIGHT: usize = 10;
             const SCALE: f32 = 1. / 4.;

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -222,7 +222,7 @@ fn main() {
     w.maintain();
 
     // Insert a component, associated with `e`.
-    w.write().insert(e, CompFloat(4.0));
+    w.write_storage().insert(e, CompFloat(4.0));
 
     dispatcher.dispatch(&w.res);
     w.maintain();

--- a/examples/saveload.rs
+++ b/examples/saveload.rs
@@ -155,5 +155,5 @@ fn main() {
 
     Deserialize.run_now(&world.res);
 
-    println!("{:#?}", (&world.read::<Pos>()).join().collect::<Vec<_>>());
+    println!("{:#?}", (&world.read_storage::<Pos>()).join().collect::<Vec<_>>());
 }

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -16,7 +16,7 @@ struct SysA {
 
 impl SysA {
     fn new(world: &mut World) -> Self {
-        let mut components = world.write::<TrackedComponent>();
+        let mut components = world.write_storage::<TrackedComponent>();
         let readerid = components.track_modified();
         SysA {
             modified_id: readerid,

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -32,7 +32,7 @@ use world::{Entity, Index};
 ///     .iter()
 ///     .cloned()
 ///     .collect::<ChangeSet<i32>>();
-/// for (health, modifier) in (&mut world.write::<Health>(), &changeset).join() {
+/// for (health, modifier) in (&mut world.write_storage::<Health>(), &changeset).join() {
 ///     health.0 -= modifier;
 /// }
 /// # }
@@ -173,10 +173,10 @@ mod tests {
             .iter()
             .cloned()
             .collect::<ChangeSet<i32>>();
-        for (health, modifier) in (&mut world.write::<Health>(), &changeset).join() {
+        for (health, modifier) in (&mut world.write_storage::<Health>(), &changeset).join() {
             health.0 -= modifier;
         }
-        let healths = world.read::<Health>();
+        let healths = world.read_storage::<Health>();
         assert_eq!(68, healths.get(a).unwrap().0);
         assert_eq!(175, healths.get(b).unwrap().0);
         assert_eq!(300, healths.get(c).unwrap().0);

--- a/src/common.rs
+++ b/src/common.rs
@@ -335,7 +335,7 @@ mod test {
         // Sequential dispatch used in order to avoid missing panics due to them happening in
         // another thread.
         dispatcher.dispatch_seq(&mut world.res);
-        let components = world.read::<TestComponent>();
+        let components = world.read_storage::<TestComponent>();
         assert!(components.get(success).is_some());
         assert!(components.get(error).is_none());
         assert_eq!(

--- a/src/join.rs
+++ b/src/join.rs
@@ -84,8 +84,8 @@ bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}
 /// world.register::<Vel>();
 ///
 /// {
-///     let pos = world.read::<Pos>();
-///     let vel = world.read::<Vel>();
+///     let pos = world.read_storage::<Pos>();
+///     let vel = world.read_storage::<Vel>();
 ///
 ///     // There are no entities yet, so no pair will be returned.
 ///     let joined: Vec<_> = (&pos, &vel).join().collect();
@@ -98,8 +98,8 @@ bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}
 ///     .build();
 ///
 /// {
-///     let pos = world.read::<Pos>();
-///     let vel = world.read::<Vel>();
+///     let pos = world.read_storage::<Pos>();
+///     let vel = world.read_storage::<Vel>();
 ///
 ///     // Although there is an entity, it only has `Pos`.
 ///     let joined: Vec<_> = (&pos, &vel).join().collect();
@@ -112,8 +112,8 @@ bitset_and!{A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}
 ///     .build();
 ///
 /// {
-///     let pos = world.read::<Pos>();
-///     let vel = world.read::<Vel>();
+///     let pos = world.read_storage::<Pos>();
+///     let vel = world.read_storage::<Vel>();
 ///
 ///     // Now there is one entity that has both a `Vel` and a `Pos`.
 ///     let joined: Vec<_> = (&pos, &vel).join().collect();
@@ -216,8 +216,8 @@ impl<J: Join> JoinIter<J> {
     ///
     /// // Later
     /// {
-    ///     let mut pos = world.write::<Pos>();
-    ///     let vel = world.read::<Vel>();
+    ///     let mut pos = world.write_storage::<Pos>();
+    ///     let vel = world.read_storage::<Vel>();
     ///
     ///     assert_eq!(
     ///         Some((&mut Pos, &Vel)),
@@ -227,12 +227,12 @@ impl<J: Join> JoinIter<J> {
     /// }
     ///
     /// // The entity has found nice spot and doesn't need to move anymore.
-    /// world.write::<Vel>().remove(entity);
+    /// world.write_storage::<Vel>().remove(entity);
     ///
     /// // Even later
     /// {
-    ///     let mut pos = world.write::<Pos>();
-    ///     let vel = world.read::<Vel>();
+    ///     let mut pos = world.write_storage::<Pos>();
+    ///     let vel = world.read_storage::<Vel>();
     ///
     ///     assert_eq!(
     ///         None,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,8 @@
 
 pub use hibitset::BitSet;
 pub use join::{Join, ParJoin};
-pub use shred::{Dispatcher, DispatcherBuilder, Read, ReadExpect, RunNow, System, SystemData,
-                Write, WriteExpect};
+pub use shred::{Dispatcher, DispatcherBuilder, Read, ReadExpect, Resources, RunNow, System,
+                SystemData, Write, WriteExpect};
 pub use shrev::ReaderId;
 
 #[cfg(not(target_os = "emscripten"))]

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -40,7 +40,7 @@ impl<'a> EntityBuilder<'a> {
         M: Marker,
     {
         let mut alloc = self.world.write_resource::<M::Allocator>();
-        alloc.mark(self.entity, &mut self.world.write::<M>());
+        alloc.mark(self.entity, &mut self.world.write_storage::<M>());
 
         self
     }
@@ -134,7 +134,7 @@ impl<'a> EntityBuilder<'a> {
 ///     );
 ///
 ///     let entity = world.create_entity().marked::<NetMarker>().build();
-///     let storage = &mut world.write::<NetMarker>();
+///     let storage = &mut world.write_storage::<NetMarker>();
 ///     let marker = storage.get(entity).unwrap().clone();
 ///     assert_eq!(
 ///         world.write_resource::<NetNode>().retrieve_entity(marker, storage, &*world.entities()),

--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -33,8 +33,8 @@ use world::{Component, EntitiesRes};
 /// # struct Vel; impl Component for Vel { type Storage = VecStorage<Self>; }
 /// #
 /// # let mut world = World::new(); world.register::<Pos>(); world.register::<Vel>();
-/// # let pos_storage = world.read::<Pos>();
-/// # let vel_storage = world.read::<Vel>();
+/// # let pos_storage = world.read_storage::<Pos>();
+/// # let vel_storage = world.read_storage::<Vel>();
 /// (&pos_storage, &vel_storage).join()
 /// # ;
 /// ```
@@ -64,8 +64,8 @@ use world::{Component, EntitiesRes};
 ///     .with(Vel)
 ///     .build();
 ///
-/// # let pos_storage = world.read::<Pos>();
-/// # let vel_storage = world.read::<Vel>();
+/// # let pos_storage = world.read_storage::<Pos>();
+/// # let vel_storage = world.read_storage::<Vel>();
 /// assert_eq!(pos_storage.get(entity1), Some(&Pos));
 /// assert_eq!(pos_storage.get(entity2), None);
 ///
@@ -162,7 +162,7 @@ where
 /// let entity = world.create_entity()
 ///     .with(Pos(2.0))
 ///     .build();
-/// # let mut pos_storage = world.write::<Pos>();
+/// # let mut pos_storage = world.write_storage::<Pos>();
 ///
 /// assert_eq!(pos_storage.get_mut(entity), Some(&mut Pos(2.0)));
 /// if let Some(pos) = pos_storage.get_mut(entity) {
@@ -187,7 +187,7 @@ where
 /// let entity = world.create_entity()
 ///     .with(Pos(0.1))
 ///     .build();
-/// # let mut pos_storage = world.write::<Pos>();
+/// # let mut pos_storage = world.write_storage::<Pos>();
 ///
 /// let res = pos_storage.insert(entity, Pos(4.0));
 /// assert_eq!(res, InsertResult::Updated(Pos(0.1)));

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -54,7 +54,7 @@ mod tests {
         world.create_entity().build();
         let e = world.create_entity().with(Comp).build();
 
-        let mut comps = world.write::<Comp>();
+        let mut comps = world.write_storage::<Comp>();
         let entities = world.entities();
 
         {

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -116,7 +116,7 @@ use world::{Component, Index};
 ///     //
 ///     // Otherwise you won't receive any of the modifications until
 ///     // you start tracking them.
-///     let mut comps = world.write::<Comp>();
+///     let mut comps = world.write_storage::<Comp>();
 ///     let comp_system = CompSystem {
 ///         modified_id: comps.track_modified(),
 ///         inserted_id: comps.track_inserted(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -368,7 +368,7 @@ where
     /// # let mut world = World::new();
     /// # world.register::<Comp>();
     /// # let entity = world.create_entity().build();
-    /// # let mut storage = world.write::<Comp>();
+    /// # let mut storage = world.write_storage::<Comp>();
     ///  if let Ok(entry) = storage.entry(entity) {
     ///      entry.or_insert(Comp { field: 55 });
     ///  }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -9,7 +9,7 @@ where
 {
     world.register::<T>();
 
-    world.write()
+    world.write_storage()
 }
 
 mod map_test {
@@ -498,7 +498,7 @@ mod test {
         w.register::<Cnull>();
         let e = w.create_entity().build();
 
-        let mut null = w.write::<Cnull>();
+        let mut null = w.write_storage::<Cnull>();
 
         assert_eq!(null.get(e), None);
         assert_eq!(null.insert(e, Cnull), InsertResult::Inserted);
@@ -512,7 +512,7 @@ mod test {
 
         let mut w = World::new();
         w.register::<Cvec>();
-        let mut s1: Storage<Cvec, _> = w.write();
+        let mut s1: Storage<Cvec, _> = w.write_storage();
         let mut components = HashSet::new();
 
         for i in 0..50 {
@@ -550,7 +550,7 @@ mod test {
 
         let mut w = World::new();
         w.register::<Cvec>();
-        let mut s1: Storage<Cvec, _> = w.write();
+        let mut s1: Storage<Cvec, _> = w.write_storage();
         let mut components = HashSet::new();
 
         for i in 0..50 {
@@ -597,7 +597,7 @@ mod test {
         let e5 = w.create_entity().build();
         let e6 = w.create_entity().with(Cvec(10)).build();
 
-        let mut s1 = w.write::<Cvec>();
+        let mut s1 = w.write_storage::<Cvec>();
 
         // Basic entry usage.
         if let Ok(entry) = s1.entry(e1) {
@@ -671,7 +671,7 @@ mod test {
 
         let mut w = World::new();
         w.register::<CMarker>();
-        let mut s1: Storage<CMarker, _> = w.write();
+        let mut s1: Storage<CMarker, _> = w.write_storage();
 
         for i in 0..50 {
             s1.insert(Entity::new(i, Generation::new(1)), CMarker);
@@ -695,7 +695,7 @@ mod test {
 
         let mut w = World::new();
         w.register::<CMarker>();
-        let mut s1: Storage<CMarker, _> = w.write();
+        let mut s1: Storage<CMarker, _> = w.write_storage();
 
         for i in 0..50 {
             s1.insert(Entity::new(i, Generation::new(1)), CMarker);
@@ -711,7 +711,7 @@ mod test {
         let mut w = World::new();
         w.register::<FlaggedCvec>();
 
-        let mut s1: Storage<FlaggedCvec, _> = w.write();
+        let mut s1: Storage<FlaggedCvec, _> = w.write_storage();
 
         let mut inserted = BitSet::new();
         let mut inserted_id = s1.track_inserted();
@@ -829,7 +829,7 @@ mod serialize_test {
             .build();
         world.create_entity().build();
 
-        let storage = world.read::<CompTest>();
+        let storage = world.read_storage::<CompTest>();
         let serialized = serde_json::to_string(&storage).unwrap();
         assert_eq!(
             serialized,
@@ -866,7 +866,7 @@ mod serialize_test {
             }
         "#;
 
-        let mut storage = world.write::<CompTest>();
+        let mut storage = world.write_storage::<CompTest>();
         let packed: PackedData<CompTest> = serde_json::from_str(&data).unwrap();
         assert_eq!(packed.offsets, vec![3, 7, 8]);
         assert_eq!(

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -32,7 +32,7 @@ pub type Index = u32;
 ///
 /// # struct Pos; impl Component for Pos { type Storage = VecStorage<Self>; }
 /// # let mut world = World::new(); world.register::<Pos>();
-/// # let entities = world.entities(); let positions = world.read::<Pos>();
+/// # let entities = world.entities(); let positions = world.write_storage::<Pos>();
 /// for (e, pos) in (&*entities, &positions).join() {
 ///     // Do something
 /// #   let _ = e;

--- a/src/world/lazy.rs
+++ b/src/world/lazy.rs
@@ -21,7 +21,7 @@ impl<'a> LazyBuilder<'a> {
     {
         let entity = self.entity;
         self.lazy.execute(move |world| {
-            world.write::<C>().insert(entity, component);
+            world.write_storage::<C>().insert(entity, component);
         });
 
         self
@@ -120,7 +120,7 @@ impl LazyUpdate {
         C: Component + Send + Sync,
     {
         self.execute(move |world| {
-            world.write::<C>().insert(e, c);
+            world.write_storage::<C>().insert(e, c);
         });
     }
 
@@ -156,7 +156,7 @@ impl LazyUpdate {
         I: IntoIterator<Item = (Entity, C)> + Send + Sync + 'static,
     {
         self.execute(move |world| {
-            let mut storage = world.write::<C>();
+            let mut storage = world.write_storage::<C>();
             for (e, c) in iter {
                 storage.insert(e, c);
             }
@@ -193,7 +193,7 @@ impl LazyUpdate {
         C: Component + Send + Sync,
     {
         self.execute(move |world| {
-            world.write::<C>().remove(e);
+            world.write_storage::<C>().remove(e);
         });
     }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -84,7 +84,7 @@ impl<'a> EntityBuilder<'a> {
     #[inline]
     pub fn with<T: Component>(self, c: T) -> Self {
         {
-            let mut storage = self.world.write();
+            let mut storage = self.world.write_storage();
             storage.insert(self.entity, c);
         }
 
@@ -141,9 +141,9 @@ impl<'a> EntityBuilder<'a> {
 ///     .build();
 ///
 /// {
-///     // `World::read` returns a component storage.
-///     let pos_storage = world.read::<Pos>();
-///     let vel_storage = world.read::<Vel>();
+///     // `World::read_storage` returns a component storage.
+///     let pos_storage = world.read_storage::<Pos>();
+///     let vel_storage = world.read_storage::<Vel>();
 ///
 ///     // `Storage::get` allows to get a component from it:
 ///     assert_eq!(pos_storage.get(b), Some(&Pos { x: 3.0, y: 5.0 }));
@@ -154,8 +154,8 @@ impl<'a> EntityBuilder<'a> {
 ///
 /// {
 ///     // This time, we write to the `Pos` storage:
-///     let mut pos_storage = world.write::<Pos>();
-///     let vel_storage = world.read::<Vel>();
+///     let mut pos_storage = world.write_storage::<Pos>();
+///     let vel_storage = world.read_storage::<Vel>();
 ///
 ///     assert!(pos_storage.get(empty).is_none());
 ///
@@ -287,25 +287,25 @@ impl World {
         }
     }
 
-    /// Fetches a component's storage with the default id for reading.
+    /// Fetches a component's storage for reading.
     ///
     /// ## Panics
     ///
     /// Panics if it is already borrowed mutably.
     /// Panics if the component has not been registered.
-    pub fn read<T: Component>(&self) -> ReadStorage<T> {
+    pub fn read_storage<T: Component>(&self) -> ReadStorage<T> {
         use shred::SystemData;
 
         SystemData::fetch(&self.res)
     }
 
-    /// Fetches a component's storage with the default id for writing.
+    /// Fetches a component's storage for writing.
     ///
     /// ## Panics
     ///
     /// Panics if it is already borrowed (either immutably or mutably).
     /// Panics if the component has not been registered.
-    pub fn write<T: Component>(&self) -> WriteStorage<T> {
+    pub fn write_storage<T: Component>(&self) -> WriteStorage<T> {
         use shred::SystemData;
 
         SystemData::fetch(&self.res)

--- a/src/world/tests.rs
+++ b/src/world/tests.rs
@@ -30,7 +30,7 @@ fn delete_all() {
     world.delete_all();
 
     assert_eq!(world.entities().join().count(), 0);
-    assert!(world.read::<Pos>().get(b).is_none());
+    assert!(world.read_storage::<Pos>().get(b).is_none());
 }
 
 #[test]
@@ -52,9 +52,9 @@ fn lazy_insertion() {
     }
 
     world.maintain();
-    assert!(world.read::<Pos>().get(e1).is_some());
-    assert!(world.read::<Vel>().get(e1).is_some());
-    assert!(world.read::<Vel>().get(e2).is_some());
+    assert!(world.read_storage::<Pos>().get(e1).is_some());
+    assert!(world.read_storage::<Vel>().get(e1).is_some());
+    assert!(world.read_storage::<Vel>().get(e2).is_some());
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn lazy_removal() {
     }
 
     world.maintain();
-    assert!(world.read::<Pos>().get(e).is_none());
+    assert!(world.read_storage::<Pos>().get(e).is_none());
 }
 
 #[test]
@@ -84,12 +84,12 @@ fn lazy_execution() {
     {
         let lazy = world.read_resource::<LazyUpdate>();
         lazy.execute(move |world| {
-            world.write::<Pos>().insert(e, Pos);
+            world.write_storage::<Pos>().insert(e, Pos);
         });
     }
 
     world.maintain();
-    assert!(world.read::<Pos>().get(e).is_some());
+    assert!(world.read_storage::<Pos>().get(e).is_some());
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -280,7 +280,7 @@ fn register_idempotency() {
     w.register::<CompInt>();
 
     // ...this would end up trying to unwrap a `None`.
-    let i = w.read::<CompInt>().get(e).unwrap().0;
+    let i = w.read_storage::<CompInt>().get(e).unwrap().0;
     assert_eq!(i, 10);
 }
 
@@ -450,8 +450,8 @@ fn getting_specific_entity_with_join() {
         .build();
 
     let entity = {
-        let ints = world.read::<CompInt>();
-        let mut bools = world.write::<CompBool>();
+        let ints = world.read_storage::<CompInt>();
+        let mut bools = world.write_storage::<CompBool>();
         let entity = world.entities().join().next().unwrap();
 
         assert_eq!(
@@ -471,8 +471,8 @@ fn getting_specific_entity_with_join() {
         .with(CompInt(2))
         .with(CompBool(false))
         .build();
-    let ints = world.read::<CompInt>();
-    let mut bools = world.write::<CompBool>();
+    let ints = world.read_storage::<CompInt>();
+    let mut bools = world.write_storage::<CompBool>();
     assert_eq!(
         None,
         (&ints, &mut bools).join().get(entity, &world.entities())


### PR DESCRIPTION
PR based on conversation here: https://gitter.im/slide-rs/specs?at=5ae0cb975d7286b43a698dbc

Basically these functions now have slightly confusing names, so this PR makes them less ambiguous.  Additionally it re-exports `shred::Resources` to make the `System::setup` function easier to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/375)
<!-- Reviewable:end -->
