### PR TITLE
Rename World::exec to World::execute

### DIFF
--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -309,14 +309,14 @@ impl World {
     ///     field: i32,
     /// }
     ///
-    /// world.exec(|(mut my_res,): (Write<MyRes>,)| {
+    /// world.execute(|(mut my_res,): (Write<MyRes>,)| {
     ///     assert_eq!(my_res.field, 0);
     ///     my_res.field = 5;
     /// });
     ///
     /// assert_eq!(world.read_resource::<MyRes>().field, 5);
     /// ```
-    pub fn exec<'a, F, R, T>(&'a mut self, f: F) -> R
+    pub fn execute<'a, F, R, T>(&'a mut self, f: F) -> R
     where
         F: FnOnce(T) -> R,
         T: SystemData<'a>,


### PR DESCRIPTION
Rename `World::exec` to be consistent with `LazyUpdate::execute`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/381)
<!-- Reviewable:end -->
