### PR TITLE
fix: Reexport ParallelIterator so users don't have to add a rayon dependency directly to use par_join

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,8 @@ pub use shrev::ReaderId;
 
 #[cfg(not(target_os = "emscripten"))]
 pub use shred::AsyncDispatcher;
+#[cfg(not(target_os = "emscripten"))]
+pub use rayon::iter::ParallelIterator;
 
 pub use changeset::ChangeSet;
 pub use storage::{DenseVecStorage, FlaggedStorage, InsertedFlag, ModifiedFlag, NullStorage,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/407)
<!-- Reviewable:end -->
