### PR TITLE
Increase tuple size for SerializeComponents/DeserializeComponents

### DIFF
--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -220,4 +220,12 @@ deserialize_components!(
     CF => SF,
     CG => SG,
     CH => SH,
+    CI => SI,
+    CJ => SJ,
+    CK => SK,
+    CL => SL,
+    CN => SN,
+    CM => SM,
+    CO => SO,
+    CP => SP,
 );

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -174,4 +174,12 @@ serialize_components!(
     CF => SF,
     CG => SG,
     CH => SH,
+    CI => SI,
+    CJ => SJ,
+    CK => SK,
+    CL => SL,
+    CN => SN,
+    CM => SM,
+    CO => SO,
+    CP => SP,
 );


### PR DESCRIPTION
The short-term solution for https://github.com/slide-rs/specs/issues/414

I tried adding more, but it looks like 16 is the maximum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/415)
<!-- Reviewable:end -->
