### PR TITLE
Expose the wrapped storage from Read/WriteStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.11.2
+
+* Add `unprotected_storage()` and `unprotected_storage_mut()` methods to `Storage` ([#419])
+
+[#419]: https://github.com/slide-rs/specs/pull/419
+
 ## 0.11.1
 
 * Add diagrams to book, small code fixes in the book ([#412], [#416], [#417])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs"
-version = "0.11.1"
+version = "0.11.2"
 description = """
 Specs is an Entity-Component System library written in Rust.
 """

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -192,6 +192,11 @@ where
     T: Component,
     D: Deref<Target = MaskedStorage<T>>,
 {
+    /// Gets the wrapped storage.
+    pub fn storage(&self) -> &T::Storage {
+        &self.data.inner
+    }
+
     /// Tries to read the data associated with an `Entity`.
     pub fn get(&self, e: Entity) -> Option<&T> {
         if self.data.mask.contains(e.id()) && self.entities.is_alive(e) {
@@ -317,6 +322,11 @@ where
     T: Component,
     D: DerefMut<Target = MaskedStorage<T>>,
 {
+    /// Gets mutable access to the wrapped storage.
+    pub fn storage_mut(&mut self) -> &mut T::Storage {
+        &mut self.data.inner
+    }
+
     /// Tries to mutate the data associated with an `Entity`.
     pub fn get_mut(&mut self, e: Entity) -> Option<&mut T> {
         if self.data.mask.contains(e.id()) && self.entities.is_alive(e) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -193,7 +193,7 @@ where
     D: Deref<Target = MaskedStorage<T>>,
 {
     /// Gets the wrapped storage.
-    pub fn storage(&self) -> &T::Storage {
+    pub fn unprotected_storage(&self) -> &T::Storage {
         &self.data.inner
     }
 
@@ -323,7 +323,7 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Gets mutable access to the wrapped storage.
-    pub fn storage_mut(&mut self) -> &mut T::Storage {
+    pub fn unprotected_storage_mut(&mut self) -> &mut T::Storage {
         &mut self.data.inner
     }
 


### PR DESCRIPTION
This is already possible through `Join::open` (although not very ergonomic), so there shouldn't be any soundness issues here. This is useful for using custom storages with additional methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/419)
<!-- Reviewable:end -->
