### PR TITLE
Add .marked() to LazyBuilder and fix U64MarkerAllocator not updating its index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.11.3
+
+* Add `marked()` to LazyBuilder to keep parity with EntityBuilder ([#420])
+* Fix `U64MarkerAllocator`'s internal index not being updated on `saveload::DeserializeComponents` ([#420])
+
+[#420]: https://github.com/slide-rs/specs/pull/420
+
 # 0.11.2
 
 * Add `unprotected_storage()` and `unprotected_storage_mut()` methods to `Storage` ([#419])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs"
-version = "0.11.2"
+version = "0.11.3"
 description = """
 Specs is an Entity-Component System library written in Rust.
 """

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use join::Join;
 use shred::Resource;
 use storage::{DenseVecStorage, ReadStorage, WriteStorage};
-use world::{Component, EntitiesRes, Entity, EntityBuilder};
+use world::{Component, EntitiesRes, Entity, EntityBuilder, LazyBuilder};
 
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -41,6 +41,47 @@ impl<'a> EntityBuilder<'a> {
     {
         let mut alloc = self.world.write_resource::<M::Allocator>();
         alloc.mark(self.entity, &mut self.world.write_storage::<M>());
+
+        self
+    }
+}
+
+impl<'a> LazyBuilder<'a> {
+    /// Add a `Marker` to the entity by fetching the associated allocator.
+    ///
+    /// This will be applied on the next `world.maintain()`.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// use specs::prelude::*;
+    /// use specs::saveload::{U64Marker, U64MarkerAllocator};
+    /// let mut world = World::new();
+    ///
+    /// world.register::<U64Marker>();
+    /// world.add_resource(U64MarkerAllocator::new());
+    ///
+    /// # let lazy = world.read_resource::<LazyUpdate>();
+    /// # let entities = world.entities();
+    /// let my_entity = lazy
+    ///     .create_entity(&entities)
+    ///     /* .with(Component1) */
+    ///     .marked::<U64Marker>()
+    ///     .build();
+    /// ```
+    ///
+    /// ## Panics
+    ///
+    /// Panics during `world.maintain()` in case there's no allocator
+    /// added to the `World`.
+    pub fn marked<M>(self) -> Self
+        where
+            M: Marker
+    {
+        let entity = self.entity;
+        self.lazy.exec(move |world| {
+            let mut alloc = world.write_resource::<M::Allocator>();
+            alloc.mark(entity, &mut world.write_storage::<M>());
+        });
 
         self
     }

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -354,6 +354,9 @@ impl U64MarkerAllocator {
 impl MarkerAllocator<U64Marker> for U64MarkerAllocator {
     fn allocate(&mut self, entity: Entity, id: Option<u64>) -> U64Marker {
         let marker = if let Some(id) = id {
+            if id >= self.index {
+                self.index = id + 1;
+            }
             U64Marker(id)
         } else {
             self.index += 1;

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -52,6 +52,7 @@ impl<'a> LazyBuilder<'a> {
     /// This will be applied on the next `world.maintain()`.
     ///
     /// ## Examples
+    ///
     /// ```rust
     /// use specs::prelude::*;
     /// use specs::saveload::{U64Marker, U64MarkerAllocator};

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -26,6 +26,8 @@
 mod de;
 mod marker;
 mod ser;
+#[cfg(test)]
+mod tests;
 
 pub use self::de::DeserializeComponents;
 pub use self::marker::{Marker, MarkerAllocator, U64Marker, U64MarkerAllocator};

--- a/src/saveload/tests.rs
+++ b/src/saveload/tests.rs
@@ -1,0 +1,124 @@
+extern crate ron;
+
+use super::*;
+use prelude::*;
+use error::{Error, NoError};
+
+mod marker_test {
+    use super::*;
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    struct A(i32);
+
+    impl Component for A {
+        type Storage = VecStorage<Self>;
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    struct B(bool);
+
+    impl Component for B {
+        type Storage = VecStorage<Self>;
+    }
+
+    /// Ensure that the marker correctly allocates IDs for entities that come
+    /// from mixed sources: normal entity creation, lazy creation, and
+    /// deserialization.
+    #[test]
+    fn bumps_index_after_reload() {
+        let mut world = World::new();
+
+        world.add_resource(U64MarkerAllocator::new());
+        world.register::<A>();
+        world.register::<B>();
+        world.register::<U64Marker>();
+
+        world.create_entity().with(A(32)).with(B(true)).marked::<U64Marker>().build();
+        world.create_entity().with(A(64)).with(B(false)).marked::<U64Marker>().build();
+
+        // Serialze all entities
+        let mut ser = ron::ser::Serializer::new(Some(Default::default()), true);
+
+        world.exec(|(ents, comp_a, comp_b, markers, _alloc): (Entities, ReadStorage<A>, ReadStorage<B>,
+                                                             ReadStorage<U64Marker>, Read<U64MarkerAllocator>)| {
+            SerializeComponents::<NoError, U64Marker>::serialize(
+                &(&comp_a, &comp_b),
+                &ents,
+                &markers,
+                &mut ser,
+            ).unwrap();
+        });
+
+        let serial = ser.into_output_string();
+
+        let mut de = ron::de::Deserializer::from_str(&serial).unwrap();
+
+        // Throw the old world away and deserialzie into a new world
+        let mut world = World::new();
+
+        world.add_resource(U64MarkerAllocator::new());
+        world.register::<A>();
+        world.register::<B>();
+        world.register::<U64Marker>();
+
+        world.exec(|(ents, comp_a, comp_b, mut markers, mut alloc): (Entities, WriteStorage<A>, WriteStorage<B>,
+                                                                     WriteStorage<U64Marker>, Write<U64MarkerAllocator>)| {
+            DeserializeComponents::<Error, _>::deserialize(
+                &mut (comp_a, comp_b),
+                &ents,
+                &mut markers,
+                &mut alloc,
+                &mut de,
+            ).unwrap();
+        });
+
+        // Two marked entities should be deserialized
+        assert_marked_entity_count(&mut world, 2);
+
+        // Queue lazy creation of 2 more entities
+        world.exec(|(ents, lazy): (Entities, Read<LazyUpdate>)| {
+            lazy.create_entity(&ents)
+                .with(A(128)).with(B(false)).marked::<U64Marker>().build();
+            lazy.create_entity(&ents)
+                .with(A(256)).with(B(true)).marked::<U64Marker>().build();
+        });
+
+        // Create 2 new entities besides the deserialized ones
+        world.create_entity().with(A(512)).with(B(false)).marked::<U64Marker>().build();
+        world.create_entity().with(A(1024)).with(B(true)).marked::<U64Marker>().build();
+
+        // Check that markers of deserialized entities and newly created entities are unique
+        assert_marked_entity_count(&mut world, 4);
+        assert_markers_are_unique(&mut world);
+
+        // Check that markers of lazily created entities are unique
+        world.maintain();
+        assert_marked_entity_count(&mut world, 6);
+        assert_markers_are_unique(&mut world);
+    }
+
+    /// Assert that the number of entities marked with `U64Marker` is equal to `count`
+    fn assert_marked_entity_count(world: &mut World, count: usize) {
+        world.exec(|(ents, markers): (Entities, ReadStorage<U64Marker>)| {
+            let marked_entity_count = (&*ents, &markers).join().count();
+
+            assert_eq!(marked_entity_count, count);
+        });
+    }
+
+    /// Ensure there are no duplicate marker .ids() in the world
+    fn assert_markers_are_unique(world: &mut World) {
+        world.exec(|(ents, markers): (Entities, ReadStorage<U64Marker>)| {
+            use std::collections::HashSet;
+
+            let marker_ids: Vec<_> = (&*ents, &markers)
+                .join()
+                .map(|(_entity, marker)| marker.id())
+                .collect();
+
+            let marker_id_set: HashSet<_> = marker_ids.iter().cloned().collect();
+
+            assert_eq!(marker_ids.len(), marker_id_set.len());
+        });
+    }
+}


### PR DESCRIPTION
First one (.marked()) is mostly a copy-paste from EntityBuilder.

Second one fixes what I think is a bug (if I'm using this correctly); on loading my game with `saveload::DeserializeComponents`, it reuses the markers in the saved `.ron` file, but new entities are then created starting from 0, meaning I get duplicate marker .id()'s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/420)
<!-- Reviewable:end -->
