### PR TITLE
Export component-wise saveload traits

### DIFF
--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -1,13 +1,12 @@
 use std::fmt::{self, Display, Formatter};
 use std::marker::PhantomData;
 
-use serde::de::{
-    self, Deserialize, DeserializeOwned, DeserializeSeed, Deserializer, SeqAccess, Visitor,
-};
+use serde::de::{self, Deserialize, DeserializeOwned, DeserializeSeed, Deserializer, SeqAccess,
+                Visitor};
 
 use error::NoError;
-use saveload::marker::{Marker, MarkerAllocator};
 use saveload::EntityData;
+use saveload::marker::{Marker, MarkerAllocator};
 use storage::{GenericWriteStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 

--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -1,12 +1,13 @@
 use std::fmt::{self, Display, Formatter};
 use std::marker::PhantomData;
 
-use serde::de::{self, Deserialize, DeserializeOwned, DeserializeSeed, Deserializer, SeqAccess,
-                Visitor};
+use serde::de::{
+    self, Deserialize, DeserializeOwned, DeserializeSeed, Deserializer, SeqAccess, Visitor,
+};
 
 use error::NoError;
-use saveload::EntityData;
 use saveload::marker::{Marker, MarkerAllocator};
+use saveload::EntityData;
 use storage::{GenericWriteStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
@@ -88,6 +89,71 @@ where
     }
 }
 
+/// Provides a function which converts a marked serialization wrapper
+/// into its actual component.
+///
+/// When serializing, specs will store the actual `Data` type
+/// from [`IntoSerialize`] and upon deserialization, call
+/// the `from` function to yield the real [`Component`].
+///
+/// This is automatically implemented for any type that is both
+/// a [`Component`] and [`DeserializeOwned`] (which includes
+/// any type that derives [`Deserialize`]).
+///
+/// Implementing this yourself is usually only needed if you
+/// have a component that points to another Entity and you
+/// wish to [`Deserialize`] it.
+///
+/// In most cases, you also likely want to implement the companion
+/// trait [`IntoSerialize`].
+///
+/// [`from`]: trait.FromDeserialize.html#tymethod.from
+/// [`Component`]: ../trait.Component.html
+/// [`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
+/// [`DeserializeOwned`]: https://docs.serde.rs/serde/de/trait.DeserializeOwned.html
+/// [`IntoSerialize`]: trait.IntoSerialize.html
+///
+/// # Example
+///
+/// ```rust
+/// # extern crate specs;
+/// # #[macro_use] extern crate serde;
+/// use serde::Deserialize;
+/// use specs::prelude::*;
+/// use specs::error::NoError;
+/// use specs::saveload::{Marker, FromDeserialize};
+///
+/// struct Target(Entity);
+///
+/// impl Component for Target {
+///     type Storage = VecStorage<Self>;
+/// }
+///
+/// // We need a matching "data" struct to hold our
+/// // marker. In general, you just need a single struct
+/// // per component you want to make `Deserialize` with each
+/// // instance of `Entity` replaced with a generic "M".
+/// #[derive(Deserialize)]
+/// struct TargetData<M>(M);
+///
+/// impl<M: Marker> FromDeserialize<M> for Target
+///     where
+///     for<'de> M: Deserialize<'de>,
+/// {
+///     type Data = TargetData<M>;
+///     type Error = NoError;
+///
+///     fn from<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+///     where
+///         F: FnMut(M) -> Option<Entity>
+///     {
+///         let entity = ids(data.0).unwrap();
+///         Ok(Target(entity))
+///     }
+/// }
+///
+/// ```
+///
 pub trait FromDeserialize<M>: Component {
     /// Serializable data representation for component
     type Data: DeserializeOwned;

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -29,9 +29,9 @@ mod ser;
 #[cfg(test)]
 mod tests;
 
-pub use self::de::DeserializeComponents;
+pub use self::de::{DeserializeComponents, FromDeserialize};
 pub use self::marker::{Marker, MarkerAllocator, U64Marker, U64MarkerAllocator};
-pub use self::ser::SerializeComponents;
+pub use self::ser::{IntoSerialize, SerializeComponents};
 
 /// A struct used for deserializing entity data.
 #[derive(Serialize, Deserialize)]

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -4,8 +4,8 @@ use serde::ser::{self, Serialize, SerializeSeq, Serializer};
 
 use error::NoError;
 use join::Join;
-use saveload::marker::{Marker, MarkerAllocator};
 use saveload::EntityData;
+use saveload::marker::{Marker, MarkerAllocator};
 use storage::{GenericReadStorage, ReadStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
@@ -127,8 +127,7 @@ where
         for (entity, marker) in (&*entities, &*markers).join() {
             serseq.serialize_element(&EntityData::<M, Self::Data> {
                 marker: marker.clone(),
-                components: self
-                    .serialize_entity(entity, &ids)
+                components: self.serialize_entity(entity, &ids)
                     .map_err(ser::Error::custom)?,
             })?;
         }
@@ -174,8 +173,7 @@ where
                 for (entity, marker) in to_serialize {
                     serseq.serialize_element(&EntityData::<M, Self::Data> {
                         marker,
-                        components: self
-                            .serialize_entity(entity, &mut ids)
+                        components: self.serialize_entity(entity, &mut ids)
                             .map_err(ser::Error::custom)?,
                     })?;
                 }

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -4,11 +4,65 @@ use serde::ser::{self, Serialize, SerializeSeq, Serializer};
 
 use error::NoError;
 use join::Join;
-use saveload::EntityData;
 use saveload::marker::{Marker, MarkerAllocator};
+use saveload::EntityData;
 use storage::{GenericReadStorage, ReadStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
+/// Converts a component into its serialized form.
+///
+/// This is automatically implemented for any type that is both
+/// a [`Component`] and [`Serialize`], yielding itself.
+///
+/// Implementing this yourself is usually only needed if you
+/// have a component that points to another Entity and you
+/// wish to [`Serialize`] it.
+///
+/// In most cases, you also likely want to implement the companion
+/// trait [`FromDeserialize`].
+///
+/// [`Component`]: ../trait.Component.html
+/// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
+/// [`FromDeserialize`]: trait.FromDeserialize.html
+///
+/// # Example
+///
+/// ```rust
+/// # extern crate specs;
+/// # #[macro_use] extern crate serde;
+/// use serde::Serialize;
+/// use specs::prelude::*;
+/// use specs::error::NoError;
+/// use specs::saveload::{Marker, IntoSerialize};
+///
+/// struct Target(Entity);
+///
+/// impl Component for Target {
+///     type Storage = VecStorage<Self>;
+/// }
+///
+/// // We need a matching "data" struct to hold our
+/// // marker. In general, you just need a single struct
+/// // per component you want to make `Serialize` with each
+/// // instance of `Entity` replaced with a generic "M".
+/// #[derive(Serialize)]
+/// struct TargetData<M>(M);
+///
+/// impl<M: Marker + Serialize> IntoSerialize<M> for Target {
+///     type Data = TargetData<M>;
+///     type Error = NoError;
+///
+///     fn into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+///     where
+///         F: FnMut(Entity) -> Option<M>
+///     {
+///         let marker = ids(self.0).unwrap();
+///         Ok(TargetData(marker))
+///     }
+/// }
+///
+/// ```
+///
 pub trait IntoSerialize<M>: Component {
     /// Serializable data representation for component
     type Data: Serialize;
@@ -73,7 +127,8 @@ where
         for (entity, marker) in (&*entities, &*markers).join() {
             serseq.serialize_element(&EntityData::<M, Self::Data> {
                 marker: marker.clone(),
-                components: self.serialize_entity(entity, &ids)
+                components: self
+                    .serialize_entity(entity, &ids)
                     .map_err(ser::Error::custom)?,
             })?;
         }
@@ -119,7 +174,8 @@ where
                 for (entity, marker) in to_serialize {
                     serseq.serialize_element(&EntityData::<M, Self::Data> {
                         marker,
-                        components: self.serialize_entity(entity, &mut ids)
+                        components: self
+                            .serialize_entity(entity, &mut ids)
                             .map_err(ser::Error::custom)?,
                     })?;
                 }


### PR DESCRIPTION
Exports `IntoSerialize` and `FromDeserialize` to the world, along with documentation. Doc tests pass, but are mostly just simple implementation examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/427)
<!-- Reviewable:end -->
