### PR TITLE
Saveload convenience (proc-)macros

### DIFF
--- a/specs-derive/Cargo.toml
+++ b/specs-derive/Cargo.toml
@@ -9,8 +9,12 @@ keywords = ["gamedev", "parallel", "specs", "ecs", "derive"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-syn = "0.12"
+syn = {version="0.12", features=["extra-traits"]}
 quote = "0.4"
+
+[dev-dependencies]
+specs = { path = "..", features=["serde"] }
+serde = "1"
 
 [lib]
 proc-macro = true

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -1,0 +1,496 @@
+//! Contains implementations for #[derive(Saveload)]
+//! which derives both `IntoSerialize` and `FromDeserialize`.
+//!
+//! Since this requires a proxy "Data" `struct`/`enum`, these two need
+//! to be derived together or it begins requiring unwieldy attribute explosion.
+//!
+//! Currently there is one major limitation to this implementation: it cannot handle
+//! generic types such as `struct Foo<T> { x: T, e: Entity }`. I'm not good enough at
+//! using `syn` to iron this out, but since specs requires explicit references to non-generic
+//! components in system data, it can generally be worked around by newtyping like
+//! `struct TypedFoo(Foo<u32>);` and the like.
+
+// NOTE: All examples given in the documentation below are "cleaned up" into readable Rust,
+// so it doesn't give an entirely accurate view of what's actually generated (for instance,
+// I'll write `Entity` instead of `::specs::Entity` which is actually what's generated).
+
+use quote::Tokens;
+use syn::{DataEnum, DataStruct, DeriveInput, Field, Generics, Ident, Type, TypeParamBound};
+
+// Handy collection since tuples got unwieldy and
+// unclear in purpose
+struct SaveloadDerive {
+    type_def: Tokens,
+    ser: Tokens,
+    de: Tokens,
+    saveload_name: Ident,
+    saveload_generics: Generics,
+}
+
+/// The main entrypoint, sets things up and delegates to the
+/// type we're deriving on.
+pub fn impl_saveload(ast: &mut DeriveInput) -> Tokens {
+    use syn::Data;
+
+    if !ast.generics.params.is_empty() {
+        panic!("Deriving `Saveload` does not, at the moment, support generic types (i.e. `struct Foo<T>`).
+        
+        This limitation may be fixed in the future, but for now you can usually work around this by newtyping
+        your generic data structure to a concrete-variant (e.g. `struct FooU32(Foo<u32>);`), or implementing `IntoSerialize` and `FromDeserialize` 
+        yourself, which is relatively straightforward if tedious (see the documentation for those traits).")
+    }
+
+    add_bound(
+        &mut ast.generics,
+        parse_quote!(::specs::saveload::IntoSerialize),
+    );
+    add_bound(
+        &mut ast.generics,
+        parse_quote!(::specs::saveload::FromDeserialize),
+    );
+    add_bound(&mut ast.generics, parse_quote!(Clone));
+
+    let derive = match ast.data {
+        Data::Struct(ref mut data) => saveload_struct(data, &mut ast.ident, &mut ast.generics),
+        Data::Enum(ref data) => saveload_enum(data, &ast.ident, &ast.generics),
+        Data::Union(_) => panic!("Unions cannot derive IntoSerialize/FromDeserialize at present"),
+    };
+
+    let name = ast.ident;
+
+    let mut impl_generics = ast.generics.clone();
+    impl_generics.params.push(parse_quote!(
+        MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker
+    ));
+    let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
+    let (_, ty_generics, _) = ast.generics.split_for_impl(); // We don't want the type generics we just made
+                                                             // because they have MA which our normal type doesn't have
+
+    let type_def = derive.type_def;
+    let saveload_name = derive.saveload_name;
+    let saveload_generics = derive.saveload_generics;
+
+    let ser = derive.ser;
+    let de = derive.de;
+
+    let tt = quote!{
+        #[derive(Serialize, Deserialize, Clone)]
+        #[serde(bound = "MA: ::specs::saveload::Marker")]
+        #type_def
+
+        impl #impl_generics ::specs::saveload::IntoSerialize<MA> for #name #ty_generics #where_clause {
+            type Data = #saveload_name #saveload_generics;
+            type Error = ::specs::error::NoError;
+
+            fn into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+            where
+                F: FnMut(::specs::Entity) -> Option<MA>
+            {
+                #ser
+            }
+        }
+
+        impl #impl_generics ::specs::saveload::FromDeserialize<MA> for #name #ty_generics #where_clause {
+            type Data = #saveload_name #saveload_generics;
+            type Error = ::specs::error::NoError;
+
+            fn from<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+            where
+                F: FnMut(MA) -> Option<Entity>
+            {
+                #de
+            }
+        }
+    };
+
+    // panic!("{}", tt);
+
+    tt
+}
+
+// Implements all elements of saveload common to structs of any type
+// (except unit structs like `struct Foo;` since they're auto-saveload);
+fn saveload_struct(
+    data: &mut DataStruct,
+    name: &mut Ident,
+    generics: &mut Generics,
+) -> SaveloadDerive {
+    use syn::Fields;
+
+    let mut saveload_generics = generics.clone();
+    saveload_generics.params.push(parse_quote!(MA));
+    match saveload_generics.where_clause {
+        Some(ref mut clause) => clause.predicates.push(parse_quote!(
+            MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        )),
+        ref mut clause @ None => {
+            *clause = Some(parse_quote!(
+            where MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        ))
+        }
+    }
+
+    let saveload_name = Ident::new(&format!("{}SaveloadData", name), name.span);
+
+    let saveload_fields: Vec<_> = data
+        .fields
+        .iter()
+        .cloned()
+        .map(|mut f| {
+            replace_entity_type(&mut f.ty);
+            f
+        })
+        .collect();
+
+    let (struct_def, ser, de) = if let Fields::Named(_) = data.fields {
+        saveload_named_struct(&name, &saveload_name, &saveload_generics, &saveload_fields)
+    } else if let Fields::Unnamed(_) = data.fields {
+        saveload_tuple_struct(
+            &data,
+            &name,
+            &saveload_name,
+            &saveload_generics,
+            &saveload_fields,
+        )
+    } else {
+        panic!("This derive does not support unit structs (Hint: they automatically derive FromDeserialize and IntoSerialize)");
+    };
+
+    SaveloadDerive {
+        type_def: struct_def,
+        ser,
+        de,
+        saveload_name,
+        saveload_generics,
+    }
+}
+
+// Automatically derives the two traits and proxy `Data` container for a struct with named fields (e.g. `struct Foo {e: Entity}`).
+//
+// This generates a struct named `StructNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
+//  e.g.
+//
+// ```
+// struct FooSaveloadData<MA> where MA: Serialize+Marker, for<'de> MA: Deserialize<'de> {
+//    e: <Entity as IntoSerialize<MA>>::Data
+// }
+// ```
+//
+// The generation for the `into` and `from` functions just constructs each field by calling `into`/`from` for each field in the input struct
+// and placing it into the output struct:
+//
+// ```
+//  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
+//      FooSaveloadData {
+//          e: IntoSerialize::into(&self.e, &mut ids)?
+//      }
+//  }
+// ```
+//
+// And similar for `FromDeserialize`.
+fn saveload_named_struct(
+    name: &Ident,
+    saveload_name: &Ident,
+    generics: &Generics,
+    saveload_fields: &[Field],
+) -> (Tokens, Tokens, Tokens) {
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let struct_def = quote!{
+        struct #saveload_name #ty_generics #where_clause {
+            #( #saveload_fields ),*
+        }
+    };
+
+    let field_names = saveload_fields.iter().map(|f| f.ident.clone());
+    let field_names_2 = field_names.clone();
+    let ser = quote!{
+        Ok(#saveload_name {
+                # ( #field_names: ::specs::saveload::IntoSerialize::into(&self.#field_names_2, &mut ids)? ),*
+            })
+    };
+
+    let field_names = saveload_fields.iter().map(|f| f.ident.clone());
+    let field_names_2 = field_names.clone();
+    let de = quote! { Ok(#name {
+                # ( #field_names: ::specs::saveload::FromDeserialize::from(data.#field_names_2, &mut ids)? ),*
+            })
+    };
+
+    (struct_def, ser, de)
+}
+
+// Automatically derives the two traits and proxy `Data` container for a struct with unnamed fields aka a tuple struct (e.g. `struct Foo(Entity);`).
+//
+// This generates a struct named `StructNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
+//  e.g.
+//
+// ```
+// struct FooSaveloadData<MA>  (
+//    <Entity as IntoSerialize<MA>>::Data
+// ) where MA: Serialize+Marker, for<'de> MA: Deserialize<'de>;
+// ```
+//
+// The generation for the `into` and `from` functions just constructs each field by calling `into`/`from` for each field in the input struct
+// and placing it into the output struct:
+//
+// ```
+//  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
+//      FooSaveloadData (
+//          e: IntoSerialize::into(&self.0, &mut ids)?
+//      )
+//  }
+// ```
+//
+// And similar for `FromDeserialize`.
+fn saveload_tuple_struct(
+    data: &DataStruct,
+    name: &Ident,
+    saveload_name: &Ident,
+    generics: &Generics,
+    saveload_fields: &[Field],
+) -> (Tokens, Tokens, Tokens) {
+    use syn::Index;
+
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let struct_def = quote!{
+        struct #saveload_name #ty_generics (
+            #( #saveload_fields ),*
+        ) #where_clause;
+    };
+
+    let field_ids = saveload_fields.iter().enumerate().map(|(i, _)| Index {
+        index: i as u32,
+        span: data.struct_token.0.clone(),
+    });
+    let ser = quote!{
+        Ok(#saveload_name (
+                # ( ::specs::saveload::IntoSerialize::into(&self.#field_ids, &mut ids)? ),*
+            ))
+    };
+
+    let field_ids = saveload_fields.iter().enumerate().map(|(i, _)| Index {
+        index: i as u32,
+        span: data.struct_token.0.clone(),
+    });
+    let de = quote! { Ok(#name (
+                # ( ::specs::saveload::FromDeserialize::from(data.#field_ids, &mut ids)? ),*
+            ))
+    };
+
+    (struct_def, ser, de)
+}
+
+// Automatically derives the two traits and proxy `Data` container for an Enum (e.g. `enum Foo{ Bar(Entity), Baz{ e: Entity }, Unit }`).
+//
+// This will properly handle enum variants with no `Entity`, so long as at least one variant (or one of that variant's fields recursively) contain an
+// `Entity` somewhere. If this isn't true, `Saveload` is auto-derived so long as the fields can be `Serialize` and `Deserialize` anyway.
+//
+// This generates a struct named `EnumNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
+//  e.g.
+//
+// ```
+// enum FooSaveloadData<MA> where MA: Serialize+Marker, for<'de> MA: Deserialize<'de> {
+//    Bar(<Entity as IntoSerialize<MA>>::Data),
+//    Baz { e: <Entity as IntoSerialize<MA>>::Data },
+//    Unit
+// };
+// ```
+//
+// The generation for the `into` and `from` functions just constructs each field of each variant by calling `into`/`from` for each field in the input
+// and placing it into the output struct in a giant match of each possibility:
+//
+// ```
+//  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
+//      match *self {
+//          Foo::Bar(ref field0) => FooSaveloadData::Bar(IntoSerialize::into(field0, &mut ids)? ),
+//          Foo::Baz{ ref e } => FooSaveloadData::Baz{ e: IntoSerialize::into(e, &mut ids)? },
+//          Foo::Unit => FooSaveloadData::Unit,
+//      }
+//  }
+// ```
+//
+// And similar for `FromDeserialize`.
+fn saveload_enum(data: &DataEnum, name: &Ident, generics: &Generics) -> SaveloadDerive {
+    use syn::Fields;
+
+    let mut saveload_generics = generics.clone();
+    saveload_generics.params.push(parse_quote!(MA));
+
+    match saveload_generics.where_clause {
+        Some(ref mut clause) => clause.predicates.push(parse_quote!(
+            MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        )),
+        ref mut clause @ None => {
+            *clause = Some(parse_quote!(
+            where MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        ))
+        }
+    }
+
+    let saveload_name = Ident::new(&format!("{}SaveloadData", name), name.span);
+
+    let mut saveload = data.clone();
+
+    for variant in saveload.variants.iter_mut() {
+        if let Fields::Unnamed(ref mut fields) = variant.fields {
+            for f in fields.unnamed.iter_mut() {
+                replace_entity_type(&mut f.ty);
+            }
+        } else if let Fields::Named(ref mut fields) = variant.fields {
+            for f in fields.named.iter_mut() {
+                replace_entity_type(&mut f.ty);
+            }
+        }
+    }
+
+    let variants = &saveload.variants;
+
+    let (_, saveload_ty_generics, saveload_where_clause) = saveload_generics.split_for_impl();
+    let enum_def = quote!{
+        enum #saveload_name #saveload_ty_generics #saveload_where_clause {
+            #( #variants ),*
+        }
+    };
+
+    let mut big_match_ser = quote!{};
+    let mut big_match_de = quote!{};
+
+    for variant in variants {
+        let ident = &variant.ident;
+
+        match variant.fields {
+            Fields::Named(ref fields) => {
+                let names = fields.named.iter().map(|f| f.ident);
+                let names_2 = fields.named.iter().map(|f| f.ident);
+                let names_3 = fields.named.iter().map(|f| f.ident);
+
+                big_match_ser = quote!{
+                    #big_match_ser
+                    #name::#ident { #( ref #names ),* } => #saveload_name::#ident { #( #names_3: ::specs::saveload::IntoSerialize::into(#names_2, ids)? ),* },
+                };
+
+                let names = fields.named.iter().map(|f| f.ident);
+                let names_2 = fields.named.iter().map(|f| f.ident);
+                let names_3 = fields.named.iter().map(|f| f.ident);
+
+                big_match_de = quote!{
+                    #big_match_de
+                    #saveload_name::#ident { #( #names ),* } => #name::#ident { #( #names_3: ::specs::saveload::FromDeserialize::from(#names_2, &mut ids)? ),* },
+                };
+            }
+            Fields::Unnamed(ref fields) => {
+                let field_ids: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(i, _)| Some(Ident::new(&format!("field{}", i), data.enum_token.0)))
+                    .collect();
+
+                let field_ids_2 = field_ids.clone();
+
+                big_match_ser = quote!{
+                    #big_match_ser
+                    #name::#ident( #( ref #field_ids ),* ) => #saveload_name::#ident( #( ::specs::saveload::IntoSerialize::into(#field_ids_2, &mut ids)? ),* ),
+                };
+
+                let field_ids: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(i, _)| Some(Ident::new(&format!("field{}", i), data.enum_token.0)))
+                    .collect();
+
+                let field_ids_2 = field_ids.clone();
+
+                big_match_de = quote!{
+                    #big_match_de
+                    #saveload_name::#ident( #( #field_ids ),* ) => #name::#ident( #( ::specs::saveload::FromDeserialize::from(#field_ids_2, &mut ids)? ),* ),
+                };
+            }
+            Fields::Unit => {
+                big_match_ser = quote! {
+                    #big_match_ser
+                    #name::#ident => #saveload_name::#ident,
+                };
+
+                big_match_de = quote! {
+                    #big_match_de
+                    #saveload_name::#ident => #name::#ident,
+                };
+            }
+        }
+    }
+
+    let ser = quote!{
+        Ok(match *self {
+            #big_match_ser
+        })
+    };
+
+    let de = quote!{
+        Ok(match data {
+            #big_match_de
+        })
+    };
+
+    SaveloadDerive {
+        type_def: enum_def,
+        ser,
+        de,
+        saveload_name,
+        saveload_generics: saveload_generics.clone(), // dumb borrow checker, don't feel like fixing because it's probably NBD
+    }
+}
+
+// Edits the bounds of the input type to ensure all fields have `bound`.
+fn add_bound(generics: &mut Generics, bound: TypeParamBound) {
+    use syn::GenericParam;
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            if type_param.bounds.iter().position(|b| bound == *b).is_some() {
+                continue;
+            }
+            type_param.bounds.push(bound.clone());
+        }
+    }
+}
+
+// Replaces the type with its corresponding `Data` type.
+fn replace_entity_type(ty: &mut Type) {
+    match *ty {
+        Type::Array(ref mut ty) => replace_entity_type(&mut *ty.elem),
+        Type::Tuple(ref mut ty) => {
+            for ty in ty.elems.iter_mut() {
+                replace_entity_type(&mut *ty);
+            }
+        }
+        Type::Paren(ref mut ty) => replace_entity_type(&mut *ty.elem),
+        Type::Path(ref mut ty) => {
+            let ty_tok = ty.clone();
+            *ty = parse_quote!(<#ty_tok as ::specs::saveload::IntoSerialize<MA>>::Data);
+        }
+        Type::Group(ref mut ty) => replace_entity_type(&mut *ty.elem),
+
+        Type::TraitObject(_) => {}
+        Type::ImplTrait(_) => {}
+        Type::Slice(_) => {
+            panic!("Slices are unsupported, use owned types like Vecs or Arrays instead")
+        }
+        Type::Reference(_) => panic!("References are unsupported"),
+        Type::Ptr(_) => panic!("Raw pointer types are unsupported"),
+        Type::BareFn(_) => panic!("Function types are unsupported"),
+        /* We're in a struct so it doesn't matter */
+        Type::Never(_) => unreachable!(),
+        Type::Infer(_) => unreachable!(),
+        Type::Macro(_) => unreachable!(),
+        Type::Verbatim(_) => unimplemented!(),
+    }
+}

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -76,7 +76,7 @@ pub fn impl_saveload(ast: &mut DeriveInput) -> Tokens {
     let tt = quote!{
         #[derive(Serialize, Deserialize, Clone)]
         #[serde(bound = "MA: ::specs::saveload::Marker")]
-        #type_def
+        pub #type_def
 
         impl #impl_generics ::specs::saveload::IntoSerialize<MA> for #name #ty_generics #where_clause {
             type Data = #saveload_name #saveload_generics;

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -1,0 +1,70 @@
+// These are mostly just compile tests
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate serde;
+extern crate specs;
+#[macro_use]
+extern crate specs_derive;
+
+use specs::prelude::*;
+
+#[derive(Saveload)]
+struct OneFieldNamed {
+    e: Entity,
+}
+
+#[derive(Saveload)]
+struct TwoField {
+    a: u32,
+    e: Entity,
+}
+
+// Tests a struct that owns a parent
+// that derives Saveload
+#[derive(Saveload)]
+struct LevelTwo {
+    owner: OneFieldNamed,
+}
+
+#[derive(Saveload)]
+struct OneFieldTuple(Entity);
+
+#[derive(Saveload)]
+struct TwoFieldTuple(Entity, u32);
+
+#[derive(Saveload)]
+struct LevelTwoTuple(OneFieldNamed);
+
+#[derive(Saveload)]
+enum AnEnum {
+    E(Entity),
+    F { e: Entity },
+    Unit,
+}
+
+mod tests {
+    use super::*;
+    use specs::saveload::{FromDeserialize, IntoSerialize, U64Marker};
+
+    /* Just a compile test to verify that we meet the proper bounds.
+    Does not need to be #[test] since it's a compile test */
+
+    fn type_check() {
+        let mut world = World::new();
+        let entity = world.create_entity().build();
+
+        black_box::<U64Marker, _>(OneFieldNamed { e: entity });
+        black_box::<U64Marker, _>(TwoField { a: 5, e: entity });
+        black_box::<U64Marker, _>(LevelTwo {
+            owner: OneFieldNamed { e: entity },
+        });
+        black_box::<U64Marker, _>(OneFieldTuple(entity));
+        black_box::<U64Marker, _>(TwoFieldTuple(entity, 5));
+        // The derive will work for all variants
+        // so no need to test anything but unit
+        black_box::<U64Marker, _>(AnEnum::Unit);
+    }
+
+    fn black_box<M, T: IntoSerialize<M> + FromDeserialize<M>>(_item: T) {}
+}

--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -12,6 +12,12 @@ use storage::{GenericWriteStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
 /// A trait which allows to deserialize entities and their components.
+///
+/// Instead of implementing this trait and its companion [`SerializeComponents`] directly,
+/// you may wish to use the [`saveload_components`] macro.
+///
+/// [`SerializeComponents`]: ./SerializeComponents.t.html
+/// [`saveload_components`]: ../macro.saveload_components.html
 pub trait DeserializeComponents<E, M>
 where
     Self: Sized,

--- a/src/saveload/macros.rs
+++ b/src/saveload/macros.rs
@@ -1,0 +1,211 @@
+/// This macro is a convenience wrapper for the most common method of serializing or deserializing components.
+///
+/// This takes several arguments: a list of components surrounded by brackets `[ Foo, Bar, Baz ]`,
+/// the target name of the generated deserialization system data, the
+/// target name of the serialization system data, the target name of the intermediate data struct all your
+/// components will be serialized from (essentially a big list of [`<T as IntoSerialize>::Data`]),
+/// and finally, the absolute path of the module this is invoked from (`::` for root), the latter is a workaround
+/// for some privacy issues.
+///
+/// At the site of invocation, it will create a submodule named `saveload_generated` containing the struct names
+/// given in the arguments.
+///
+/// The deserialization derives [`SystemData`] and contains:
+///
+/// - An opaque field containing the [`WriteStorage`]s to the given components, implementing [`DeserializeComponents`] (named `components`)
+/// - A [`WriteStorage`] handle to a generic [`Marker`] (named `markers`)
+/// - A [`Write`] handle to a [`MarkerAllocator`] parameterized by said [`Marker`] (named `alloc`)
+/// - The [`Entities`] resource (named `entities`)
+///
+/// The serialization struct also derives [`SystemData`] and contains:
+///
+/// - An opaque field containing the [`ReadStorage`]s to the given components, implementing [`SerializeComponents`] (named `components`)
+/// - A [`ReadStorage`] handle to a generic [`Marker`] (named `markers)
+/// - The [`Entities`] resource (named `entities`)
+///
+/// This is set up so that by making the generated a field in the [`SystemData`] for your [`System`], you automatically have every
+/// element necessary to immediately call [`DeserializeComponents::deserialize`] or [`SerializeComponents::serialize`].
+///
+///
+/// Note that this will still play nicely with non-trivial systems, provided you don't ask for any systems you give to this macro
+/// again. You can still fetch certain [`Component`]s mutably in your [`SystemData`], for instance, if you wish to derive their values instead of directly
+/// serializing them. For example:
+///
+/// ```rust
+/// # #[macro_use]
+/// # extern crate specs;
+/// # #[macro_use]
+/// # extern crate specs_derive;
+/// # #[macro_use]
+/// # extern crate serde;
+/// # #[macro_use]
+/// # extern crate shred_derive;
+/// # extern crate shred;
+/// #
+/// # use specs::prelude::*;
+/// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
+/// # #[storage(VecStorage)]
+/// # struct Foo;
+/// #
+/// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
+/// # #[storage(VecStorage)]
+/// # struct Bar;
+/// #
+/// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
+/// # #[storage(VecStorage)]
+/// # struct Baz;
+/// #
+/// saveload_components!{[Foo, Bar], Deser, Ser, Data, ::}
+///
+/// use specs::saveload::{U64MarkerAllocator, U64Marker};
+///
+/// #[derive(SystemData)]
+/// struct NonTrivial<'a> {
+///     // We could derive this from any entity with both `Foo` and `Bar` for example
+///     baz: WriteStorage<'a, Baz>,
+///     de: saveload_generated::Deser<'a, U64Marker, U64MarkerAllocator>,
+/// }
+/// # // This shadow main has to be here or we get a "macro_use must be declared in the crate root"
+/// # // error
+/// # fn main() {
+/// # }
+/// ```
+///
+/// Will allow us to do things with `Baz` while still giving us a common place to define the components we want
+/// to serialize and deserialize (reducing errors because we added one to one collection but not the other).
+///
+///
+///
+/// [`<T as IntoSerialize>::Data`]: ./saveload/IntoSerialize.t.html#associatedtype.Data
+/// [`DeserializeComponents`]: ./saveload/DeserializeComponents.t.html
+/// [`SerializeComponents`]: ./saveload/SerializeComponents.t.html
+/// [`DeserializeComponents::deserialize`]: ./saveload/DeserializeComponents.t.html#method.deserialize
+/// [`SerializeComponents::serialize`]: ./saveload/SerializeComponents.t.html#method.serialize
+/// [`Marker`]: ./saveload/Marker.t.html
+/// [`MarkerAllocator`]: ./saveload/MarkerAllocator.t.html
+/// [`WriteStorage`]: WriteStorage.t.html
+/// [`Write`]: Write.t.html
+/// [`Component`]: Component.t.html
+/// [`ReadStorage`]: ReadStorage.t.html
+/// [`Entities`]: Entities.t.html
+/// [`SystemData`]: SystemData.t.html
+#[macro_export]
+macro_rules! saveload_components {
+    ( [ $($name:ident),* ],  $deser_name:ident, $ser_name:ident, $data_name:ident, $abs_mod:tt) => {
+        mod saveload_generated {
+            #![allow(unused_imports)]
+            
+            use super::*;
+            use $crate::saveload::*;
+            use $crate::prelude::*;
+            use ::serde::{Serialize, Deserialize};
+
+            /// The serialized version of these components
+            #[allow(non_snake_case)]
+            #[derive(Serialize, Deserialize)]
+            #[serde(bound="")]
+            pub(super) struct $data_name<MA>
+            where
+                MA: Marker+::serde::Serialize,
+                for<'deser> MA: ::serde::Deserialize<'deser>,
+            {
+                $(pub(super) $name: Option<<$name as IntoSerialize<MA>>::Data> ),*
+            }
+
+            /// The generated deserializer system data
+            #[derive(SystemData)]
+            #[allow(dead_code)]
+            pub(super) struct $deser_name<'a, M: Marker, A: MarkerAllocator<M> > {
+                pub(super) markers: WriteStorage<'a, M>,
+                pub(super) entities: Entities<'a>,
+                pub(super) alloc: Write<'a, A>,
+                pub(super) components: self::deser_components::$deser_name<'a>,
+            }
+
+            pub(super) use self::deser_components::$deser_name as DeserComponents;
+
+            mod deser_components {
+                #![allow(unused_imports)]
+
+                use $crate::WriteStorage;
+                use $crate::saveload::Marker;
+                use super::*;
+
+                #[allow(non_snake_case)]
+                #[derive(SystemData)]
+                pub(crate) struct $deser_name<'a> {
+                    $( pub(super) $name: WriteStorage<'a, $name> ),*
+                }
+            }
+
+            impl<'a, M> DeserializeComponents<$crate::error::NoError, M> for self::deser_components::$deser_name<'a>
+            where 
+                M: Marker+'a,
+            {
+                type Data = $data_name<M>;
+
+                fn deserialize_entity<F>(
+                    &mut self,
+                    entity: Entity,
+                    components: Self::Data,
+                    mut ids: F,
+                ) -> Result<(), $crate::error::NoError>
+                where
+                    F: FnMut(M) -> Option<Entity> 
+                {
+                    $(if let Some(comp) = components.$name {
+                        let comp: $name = FromDeserialize::from(comp, &mut ids)?;
+                        self.$name.insert(entity, comp).unwrap();
+                    });*
+
+                    Ok(())
+                }
+            }
+
+            /// The generated deserializer system data
+            #[derive(SystemData)]
+            #[allow(dead_code)]
+            pub(super) struct $ser_name<'a, M: Marker> {
+                pub(super) markers: ReadStorage<'a, M>,
+                pub(super) entities: Entities<'a>,
+                pub(super) components: self::ser_components::$ser_name<'a>,
+            }
+
+            pub(super) use self::ser_components::$ser_name as SerComponents;
+
+            mod ser_components {
+                #![allow(unused_imports)]
+
+                use $crate::ReadStorage;
+                use $crate::saveload::Marker;
+                use super::*;
+
+                #[allow(non_snake_case)]
+                #[derive(SystemData)]
+                pub(crate) struct $ser_name<'a> {
+                    $( pub(super) $name: ReadStorage<'a, $name> ),*
+                }
+            }
+
+            impl<'a, M> SerializeComponents<$crate::error::NoError, M> for self::ser_components::$ser_name<'a>
+            where 
+                M: Marker, 
+            {
+                type Data = $data_name<M>;
+
+                fn serialize_entity<F>(&self, entity: Entity, mut ids: F) -> Result<Self::Data, $crate::error::NoError>
+                where
+                    F: FnMut(Entity) -> Option<M>
+                {
+                    Ok($data_name {
+                        $($name: if let Some(comp) = self.$name.get(entity) {
+                            Some(IntoSerialize::into(comp, &mut ids).unwrap())
+                        } else { 
+                            None 
+                        }),*   
+                    })
+                }
+            }
+        }
+    }
+}

--- a/src/saveload/macros.rs
+++ b/src/saveload/macros.rs
@@ -43,15 +43,15 @@
 /// # use specs::prelude::*;
 /// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
 /// # #[storage(VecStorage)]
-/// # struct Foo;
+/// # pub struct Foo;
 /// #
 /// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
 /// # #[storage(VecStorage)]
-/// # struct Bar;
+/// # pub struct Bar;
 /// #
 /// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
 /// # #[storage(VecStorage)]
-/// # struct Baz;
+/// # pub struct Baz;
 /// #
 /// saveload_components!{[Foo, Bar], Deser, Ser, Data}
 ///
@@ -102,27 +102,30 @@ macro_rules! saveload_components {
             #[allow(non_snake_case)]
             #[derive(Serialize, Deserialize)]
             #[serde(bound="")]
-            pub(crate) struct $data_name<MA>
+            #[doc(hidden)]
+            pub struct $data_name<MA>
             where
                 MA: Marker+::serde::Serialize,
                 for<'deser> MA: ::serde::Deserialize<'deser>,
             {
-                $(pub(crate) $name: Option<<$name as IntoSerialize<MA>>::Data> ),*
+                $(pub $name: Option<<$name as IntoSerialize<MA>>::Data> ),*
             }
 
             /// The generated deserializer system data
             #[derive(SystemData)]
             #[allow(dead_code)]
-            pub(crate) struct $deser_name<'a, M: Marker, A: MarkerAllocator<M> > {
-                pub(crate) markers: WriteStorage<'a, M>,
-                pub(crate) entities: Entities<'a>,
-                pub(crate) alloc: Write<'a, A>,
-                pub(crate) components: self::deser_components::$deser_name<'a>,
+            #[doc(hidden)]
+            pub struct $deser_name<'a, M: Marker, A: MarkerAllocator<M> > {
+                pub markers: WriteStorage<'a, M>,
+                pub entities: Entities<'a>,
+                pub alloc: Write<'a, A>,
+                pub components: self::deser_components::$deser_name<'a>,
             }
 
-            pub(crate) use self::deser_components::$deser_name as DeserComponents;
+            pub use self::deser_components::$deser_name as DeserComponents;
 
-            mod deser_components {
+            #[doc(hidden)]
+            pub mod deser_components {
                 #![allow(unused_imports)]
 
                 use $crate::WriteStorage;
@@ -131,8 +134,9 @@ macro_rules! saveload_components {
 
                 #[allow(non_snake_case)]
                 #[derive(SystemData)]
-                pub(crate) struct $deser_name<'a> {
-                    $( pub(crate) $name: WriteStorage<'a, $name> ),*
+                #[doc(hidden)]
+                pub struct $deser_name<'a> {
+                    $( pub $name: WriteStorage<'a, $name> ),*
                 }
             }
 
@@ -163,15 +167,17 @@ macro_rules! saveload_components {
             /// The generated deserializer system data
             #[derive(SystemData)]
             #[allow(dead_code)]
-            pub(crate) struct $ser_name<'a, M: Marker> {
-                pub(crate) markers: ReadStorage<'a, M>,
-                pub(crate) entities: Entities<'a>,
-                pub(crate) components: self::ser_components::$ser_name<'a>,
+            #[doc(hidden)]
+            pub struct $ser_name<'a, M: Marker> {
+                pub markers: ReadStorage<'a, M>,
+                pub entities: Entities<'a>,
+                pub components: self::ser_components::$ser_name<'a>,
             }
 
-            pub(crate) use self::ser_components::$ser_name as SerComponents;
+            pub use self::ser_components::$ser_name as SerComponents;
 
-            mod ser_components {
+            #[doc(hidden)]
+            pub mod ser_components {
                 #![allow(unused_imports)]
 
                 use $crate::ReadStorage;
@@ -180,8 +186,9 @@ macro_rules! saveload_components {
 
                 #[allow(non_snake_case)]
                 #[derive(SystemData)]
-                pub(crate) struct $ser_name<'a> {
-                    $( pub(crate) $name: ReadStorage<'a, $name> ),*
+                #[doc(hidden)]
+                pub struct $ser_name<'a> {
+                    $( pub $name: ReadStorage<'a, $name> ),*
                 }
             }
 

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -23,6 +23,8 @@
 //! see the docs for the `Marker` trait.
 //!
 
+mod macros;
+
 mod de;
 mod marker;
 mod ser;

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -119,6 +119,12 @@ where
 }
 
 /// A trait which allows to serialize entities and their components.
+///
+/// Instead of implementing this trait and its companion [`DeserializeComponents`] directly,
+/// you may wish to use the [`saveload_components`] macro.
+///
+/// [`DeserializeComponents`]: ./DeserializeComponents.t.html
+/// [`saveload_components`]: ../macro.saveload_components.html
 pub trait SerializeComponents<E, M>
 where
     M: Marker,

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -4,25 +4,36 @@ use serde::ser::{self, Serialize, SerializeSeq, Serializer};
 
 use error::NoError;
 use join::Join;
-use saveload::EntityData;
 use saveload::marker::{Marker, MarkerAllocator};
+use saveload::EntityData;
 use storage::{GenericReadStorage, ReadStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
-/// Converts a component into its serialized form.
+/// Converts a data type (usually a [`Component`]) into its serialized form.
 ///
-/// This is automatically implemented for any type that is both
-/// a [`Component`] and [`Serialize`], yielding itself.
+/// This is automatically implemented for any type that is
+/// [`Serialize`], yielding itself.
 ///
 /// Implementing this yourself is usually only needed if you
-/// have a component that points to another Entity and you
-/// wish to [`Serialize`] it.
+/// have a component that points to another Entity, or has a field which does,
+///  and you wish to [`Serialize`] it.
 ///
 /// In most cases, you also likely want to implement the companion
 /// trait [`FromDeserialize`].
 ///
+/// *Note*: if you're using `specs_derive`
+/// and your struct does not have a generic bound (i.e. `struct Foo<T>`),
+/// you can use `#[derive(Saveload)]` to automatically derive this and
+/// [`FromDeserialize`]. You can get around generic type bounds by exploiting
+/// the newtype pattern (e.g. `struct FooU32(Foo<u32>);`).
+///
+/// You must add the `derive` to any type that your component holds which does
+/// not auto-implement these two traits, including the component itself (similar to how
+/// normal [`Serialize`] and [`Deserialize`] work).
+///
 /// [`Component`]: ../trait.Component.html
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
+/// [`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
 /// [`FromDeserialize`]: trait.FromDeserialize.html
 ///
 /// # Example
@@ -63,14 +74,14 @@ use world::{Component, EntitiesRes, Entity};
 ///
 /// ```
 ///
-pub trait IntoSerialize<M>: Component {
-    /// Serializable data representation for component
+pub trait IntoSerialize<M> {
+    /// Serializable data representation for data type
     type Data: Serialize;
 
     /// Error may occur during serialization or deserialization of component
     type Error;
 
-    /// Convert this component into serializable form (`Data`) using
+    /// Convert this data type into serializable form (`Data`) using
     /// entity to marker mapping function
     fn into<F>(&self, ids: F) -> Result<Self::Data, Self::Error>
     where
@@ -79,7 +90,7 @@ pub trait IntoSerialize<M>: Component {
 
 impl<C, M> IntoSerialize<M> for C
 where
-    C: Clone + Component + Serialize,
+    C: Clone + Serialize,
 {
     type Data = Self;
     type Error = NoError;
@@ -89,6 +100,21 @@ where
         F: FnMut(Entity) -> Option<M>,
     {
         Ok(self.clone())
+    }
+}
+
+impl<M> IntoSerialize<M> for Entity
+where
+    M: Serialize,
+{
+    type Data = M;
+    type Error = NoError;
+
+    fn into<F>(&self, mut func: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        Ok(func(*self).unwrap())
     }
 }
 
@@ -127,7 +153,8 @@ where
         for (entity, marker) in (&*entities, &*markers).join() {
             serseq.serialize_element(&EntityData::<M, Self::Data> {
                 marker: marker.clone(),
-                components: self.serialize_entity(entity, &ids)
+                components: self
+                    .serialize_entity(entity, &ids)
                     .map_err(ser::Error::custom)?,
             })?;
         }
@@ -173,7 +200,8 @@ where
                 for (entity, marker) in to_serialize {
                     serseq.serialize_element(&EntityData::<M, Self::Data> {
                         marker,
-                        components: self.serialize_entity(entity, &mut ids)
+                        components: self
+                            .serialize_entity(entity, &mut ids)
                             .map_err(ser::Error::custom)?,
                     })?;
                 }
@@ -191,7 +219,7 @@ macro_rules! serialize_components {
             M: Marker,
             $(
                 $sto: GenericReadStorage<Component = $comp>,
-                $comp : IntoSerialize<M>,
+                $comp : IntoSerialize<M>+Component,
                 E: From<<$comp as IntoSerialize<M>>::Error>,
             )*
         {

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -99,6 +99,8 @@ impl<'a> System<'a> for SerSys {
 
 #[test]
 fn saveload_macro() {
+    use specs::saveload::MarkedBuilder;
+
     let mut world = setup_world();
     let entity = world
         .create_entity()

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "serde")]
+
+#[macro_use]
+extern crate specs;
+#[macro_use]
+extern crate specs_derive;
+#[macro_use]
+extern crate shred_derive;
+#[macro_use]
+extern crate serde;
+extern crate ron;
+extern crate serde_json;
+extern crate shred;
+
+use specs::prelude::*;
+use specs::saveload::{U64Marker, U64MarkerAllocator};
+
+#[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
+#[storage(VecStorage)]
+struct Pos {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
+#[storage(VecStorage)]
+struct Vel {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Copy, Clone, Component, Saveload)]
+#[storage(VecStorage)]
+struct OwnsEntity(Entity);
+
+saveload_components!{
+    [Pos, Vel, OwnsEntity], DeData, SerData, Data, crate
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Default, Debug)]
+struct Serialized {
+    json: String,
+}
+
+#[derive(SystemData)]
+struct DeSysData<'a> {
+    de: saveload_generated::DeData<'a, U64Marker, U64MarkerAllocator>,
+    target: Read<'a, Serialized>,
+}
+
+struct DeSys;
+
+impl<'a> System<'a> for DeSys {
+    type SystemData = DeSysData<'a>;
+
+    fn run(&mut self, mut sys_data: Self::SystemData) {
+        use ron::de::Deserializer;
+        use specs::error::NoError;
+        use specs::saveload::DeserializeComponents;
+
+        if let Ok(mut de) = Deserializer::from_str(&sys_data.target.json) {
+            DeserializeComponents::<NoError, U64Marker>::deserialize(
+                &mut sys_data.de.components,
+                &sys_data.de.entities,
+                &mut sys_data.de.markers,
+                &mut sys_data.de.alloc,
+                &mut de,
+            ).unwrap();
+        }
+    }
+}
+
+struct SerSys;
+
+#[derive(SystemData)]
+struct SerSysData<'a> {
+    ser: saveload_generated::SerData<'a, U64Marker>,
+    target: Write<'a, Serialized>,
+}
+
+impl<'a> System<'a> for SerSys {
+    type SystemData = SerSysData<'a>;
+
+    fn run(&mut self, mut sys_data: Self::SystemData) {
+        use specs::error::NoError;
+        use specs::saveload::SerializeComponents;
+
+        let mut ser = ron::ser::Serializer::new(Some(Default::default()), true);
+        SerializeComponents::<NoError, U64Marker>::serialize(
+            &sys_data.ser.components,
+            &sys_data.ser.entities,
+            &sys_data.ser.markers,
+            &mut ser,
+        ).unwrap();
+
+        sys_data.target.json = ser.into_output_string();
+    }
+}
+
+#[test]
+fn saveload_macro() {
+    let mut world = setup_world();
+    let entity = world
+        .create_entity()
+        .with(Pos { x: 5.2, y: 9.1 })
+        .with(Vel { x: 0.0, y: 1.0 })
+        .marked::<U64Marker>()
+        .build();
+
+    let mut ser = SerSys;
+
+    ser.run_now(&world.res);
+
+    let mut world2 = setup_world();
+    world2.add_resource(world.read_resource::<Serialized>().clone());
+    let mut de = DeSys;
+
+    de.run_now(&world2.res);
+    world2.maintain();
+
+    let mut len = 0;
+
+    for (pos, vel) in (&world2.read_storage::<Pos>(), &world2.read_storage::<Vel>()).join() {
+        len += 1;
+        assert!(len < 2);
+
+        assert_eq!(*pos, *world.read_storage().get(entity).unwrap());
+        assert_eq!(*vel, *world.read_storage().get(entity).unwrap());
+    }
+}
+
+fn setup_world() -> World {
+    let mut world = World::new();
+
+    world.maintain();
+    world.add_resource(Serialized::default());
+    world.add_resource(U64MarkerAllocator::new());
+
+    world.register::<Pos>();
+    world.register::<Vel>();
+    world.register::<OwnsEntity>();
+    world.register::<U64Marker>();
+
+    world
+}

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -17,21 +17,21 @@ use specs::saveload::{U64Marker, U64MarkerAllocator};
 
 #[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
 #[storage(VecStorage)]
-struct Pos {
+pub struct Pos {
     x: f64,
     y: f64,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
 #[storage(VecStorage)]
-struct Vel {
+pub struct Vel {
     x: f64,
     y: f64,
 }
 
 #[derive(Copy, Clone, Component, Saveload)]
 #[storage(VecStorage)]
-struct OwnsEntity(Entity);
+pub struct OwnsEntity(Entity);
 
 saveload_components!{
     [Pos, Vel, OwnsEntity], DeData, SerData, Data

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -34,7 +34,7 @@ struct Vel {
 struct OwnsEntity(Entity);
 
 saveload_components!{
-    [Pos, Vel, OwnsEntity], DeData, SerData, Data, crate
+    [Pos, Vel, OwnsEntity], DeData, SerData, Data
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Default, Debug)]


### PR DESCRIPTION
This adds two major features:

1. A custom derive for `IntoSerialize` and `FromDeserialize` named `#[derive(Saveload)]`. It may seem odd to derive them together, but after spending significant time trying to do it the normal way (one derive per trait) it became clear that due to the requirement of "proxy" types that fill the `IntoSerialize::Data` and `FromDeserialize::Data` fields, it made sense to do it this way or you start getting into attribute hell.
2. A macro which automatically will create `SystemData` for the most common usecase of `SerializeComponents` and `DeserializeComponents`. Unlike the existing tuple auto-implementation, this generates arbitrarily large structs that you can readily plop straight into your serialization or deserialization system. It also doesn't use recursion, so it shouldn't hit any nasty macro expansion recursion limits.

I recommend reading the module comment for the `Saveload` derive, the doc comment for `saveload_components!`, and the new documentation all around for a greater overview of what this all looks like in the end. This makes using the `saveload` features much more pleasant and less stuttery. In the case of `saveload_components!` especially it lets people easily keep their Serialization and Deserialization component lists in sync which can be hugely important and has been a source of a lot of frustrating bugs for me in the past.

The current `derive` does have a major downside in that I couldn't figure out how to get it to work with generic structs, but due to the way specs works I don't find myself holding a `Foo<T>` too often anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/434)
<!-- Reviewable:end -->
