### PR TITLE
Use non-zero optimization for Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [Unreleased]
+
+* Generation now internally uses the new `NonZeroU32`, meaning `Option<Entity>` is the same size as `Entity`.
+Note this bumps the minimum supported rust version to 1.28.0 ([#447]).
+
+[#447]: https://github.com/slide-rs/specs/pull/447
+
 # 0.12.3
 
 * Add `MaybeJoin` to iterate over components without filtering the joint set ([#455])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ shrev = "1.0.0"
 shred-derive = "0.5.0"
 tuple_utils = "0.2"
 rayon = "1.0.0"
+nonzero_signed = "1.0.1"
 
 futures = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ extern crate fnv;
 extern crate hibitset;
 #[macro_use]
 extern crate log;
+extern crate nonzero_signed;
 extern crate mopa;
 extern crate rayon;
 extern crate shrev;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(nonzero)]
 #![warn(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(nonzero)]
 #![warn(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -384,7 +384,7 @@ where
             let gen = self.entities
                 .alloc
                 .generation(e.id())
-                .unwrap_or(Generation::ONE);
+                .unwrap_or(Generation::one());
             Err(WrongGeneration {
                 action: "attempting to get an entry to a storage",
                 actual_gen: gen,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -383,10 +383,8 @@ where
         } else {
             let gen = self.entities
                 .alloc
-                .generations
-                .get(e.id() as usize)
-                .cloned()
-                .unwrap_or(Generation(1));
+                .generation(e.id())
+                .unwrap_or(Generation::ONE);
             Err(WrongGeneration {
                 action: "attempting to get an entry to a storage",
                 actual_gen: gen,

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -139,7 +139,6 @@ impl Allocator {
         self.raised.add_atomic(id);
         let gen = self
             .generation(id)
-            .map(|gen| if gen.is_alive() { gen } else { gen.raised() })
             .unwrap_or(Generation::ONE);
         Entity(id, gen)
     }
@@ -320,7 +319,6 @@ impl<'a> Join for &'a EntitiesRes {
         let gen = v
             .alloc
             .generation(idx)
-            .map(|gen| if gen.is_alive() { gen } else { gen.raised() })
             .unwrap_or(Generation::ONE);
         Entity(idx, gen)
     }

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -381,16 +381,6 @@ impl Generation {
     pub fn id(self) -> i32 {
         self.0.get() as i32
     }
-
-    /// Revives and increments a dead `Generation`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if it is alive.
-    fn raised(self) -> Generation {
-        assert!(!self.is_alive());
-        unsafe { Generation(NonZeroU32::new_unchecked((1 - self.id()) as u32)) }
-    }
 }
 
 /// Convenience wrapper around Option<Generation>

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -366,6 +366,10 @@ impl<'a> Drop for EntityResBuilder<'a> {
 /// Index generation. When a new entity is placed at an old index,
 /// it bumps the `Generation` by 1. This allows to avoid using components
 /// from the entities that were deleted.
+
+// Note that conceptually, the wrapped value in a Generation is an i32. 
+// Unfortunately, NonZeroI32 was removed, forcing us to use NonZeroU32 
+// here instead.
 #[derive(Clone, Copy, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Generation(NonZeroU32);
 

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -140,6 +140,7 @@ impl Allocator {
         self.raised.add_atomic(id);
         let gen = self
             .generation(id)
+            .map(|gen| if gen.is_alive() { gen } else { gen.raised() })
             .unwrap_or(Generation::ONE);
         Entity(id, gen)
     }
@@ -320,6 +321,7 @@ impl<'a> Join for &'a EntitiesRes {
         let gen = v
             .alloc
             .generation(idx)
+            .map(|gen| if gen.is_alive() { gen } else { gen.raised() })
             .unwrap_or(Generation::ONE);
         Entity(idx, gen)
     }

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -389,6 +389,16 @@ impl Generation {
     pub fn id(self) -> i32 {
         self.0.get() as i32
     }
+
+    /// Revives and increments a dead `Generation`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if it is alive.
+    fn raised(self) -> Generation {
+        assert!(!self.is_alive());
+        unsafe { Generation(NonZeroU32::new_unchecked((1 - self.id()) as u32)) }
+    }
 }
 
 /// Convenience wrapper around Option<Generation>

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -390,6 +390,12 @@ impl Generation {
         self.0.get() as i32
     }
 
+    /// Returns `true` if entities of this `Generation` are alive.
+    #[inline]
+    pub fn is_alive(self) -> bool {
+        self.id() > 0
+    }
+
     /// Revives and increments a dead `Generation`.
     ///
     /// # Panics
@@ -415,7 +421,7 @@ impl ZeroableGeneration {
 
     /// Returns `true` if entities of this `Generation` are alive.
     #[inline]
-    fn is_alive(&self) -> bool {
+    fn is_alive(self) -> bool {
         self.id() > 0
     }
 
@@ -434,7 +440,7 @@ impl ZeroableGeneration {
     /// # Panics
     ///
     /// Panics if it is alive.
-    fn raised(&self) -> Generation {
+    fn raised(self) -> Generation {
         assert!(!self.is_alive());
         let gen = 1i32.checked_sub(self.id()).expect("generation overflow");
         Generation(unsafe { NonZeroU32::new_unchecked(gen as u32) })

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -533,13 +533,7 @@ impl World {
     /// If you want to get this functionality before a `maintain()`,
     /// you are most likely in a system; from there, just access the
     /// `Entities` resource and call the `is_alive` method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if generation is dead.
     pub fn is_alive(&self, e: Entity) -> bool {
-        assert!(e.gen().is_alive(), "Generation is dead");
-
         let alloc: &Allocator = &self.entities().alloc;
         alloc.generation(e.id()) == Some(e.gen())
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -533,7 +533,13 @@ impl World {
     /// If you want to get this functionality before a `maintain()`,
     /// you are most likely in a system; from there, just access the
     /// `Entities` resource and call the `is_alive` method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if generation is dead.
     pub fn is_alive(&self, e: Entity) -> bool {
+        assert!(e.gen().is_alive(), "Generation is dead");
+
         let alloc: &Allocator = &self.entities().alloc;
         alloc.generation(e.id()) == Some(e.gen())
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -541,11 +541,7 @@ impl World {
         assert!(e.gen().is_alive(), "Generation is dead");
 
         let alloc: &Allocator = &self.entities().alloc;
-        alloc
-            .generations
-            .get(e.id() as usize)
-            .map(|&x| x == e.gen())
-            .unwrap_or(false)
+        alloc.generation(e.id()) == Some(e.gen())
     }
 
     /// Merges in the appendix, recording all the dynamically created


### PR DESCRIPTION
As promised in issue #436, this PR uses `NonZeroU32` in `Generation`. Note this bumps the minimum supported rust version to 1.28 - is this a concern? If so I could put this under a feature flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/447)
<!-- Reviewable:end -->
