### PR TITLE
Check length of generations in allocator before killing

### DIFF
--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -66,7 +66,10 @@ impl Allocator {
 
             self.alive.remove(entity.id());
             self.raised.remove(entity.id());
-            self.generations[id].die();
+            if self.generations.len() > id {
+                self.generations[id].die();
+            }
+
             if id < self.start_from.load(Ordering::Relaxed) {
                 self.start_from.store(id, Ordering::Relaxed);
             }

--- a/src/world/tests.rs
+++ b/src/world/tests.rs
@@ -143,3 +143,24 @@ fn test_bundle() {
     world.add_bundle(TestBundle);
     assert_eq!(12, world.read_resource::<SomeResource>().v);
 }
+
+#[test]
+fn delete_and_lazy() {
+    let mut world = World::new();
+    {
+        let lazy_update = world.write_resource::<::LazyUpdate>();
+        lazy_update.exec(|world| {
+            world.entities().create();
+        })
+    }
+
+    world.maintain();
+    {
+        let lazy_update = world.write_resource::<::LazyUpdate>();
+        lazy_update.exec(|world| {
+            world.entities().create();
+        })
+    }
+
+    world.delete_all();
+}


### PR DESCRIPTION
Probably fixes https://github.com/slide-rs/specs/issues/440 but would probably be good to double check there isn't anything wrong here.

From issue on my reasoning why I think this should be enough:
> Since atomically created entities don't have a generation in the Allocator until merge  is called, so if you atomically create an entity and it is the first of  its generation, then it will be out of range and panic. And since we  remove the entity from raised a line before, then it should never be allocated in the future and should be safe to just ignore that entity on kill.


