### PR TITLE
MaybeJoin for possibly existing components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "slide-rs/specs" }
 crossbeam = "0.3.0"
 derivative = "1"
 fnv = "1.0"
-hibitset = { version = "0.5.0", features = ["parallel"] }
+hibitset = { version = "0.5.2", features = ["parallel"] }
 log = "0.4"
 mopa = "0.2"
 shred = "0.7.0"

--- a/src/join.rs
+++ b/src/join.rs
@@ -3,7 +3,7 @@
 use std;
 use std::cell::UnsafeCell;
 
-use hibitset::{BitIter, BitProducer, BitSet, BitSetAnd, BitSetLike, BitSetNot};
+use hibitset::{BitIter, BitProducer, BitSetAll, BitSetAnd, BitSetLike};
 use rayon::iter::plumbing::{bridge_unindexed, Folder, UnindexedConsumer, UnindexedProducer};
 use rayon::iter::ParallelIterator;
 use tuple_utils::Split;
@@ -155,6 +155,54 @@ pub trait Join {
         JoinIter::new(self)
     }
 
+    /// Optionally gets a `Join` if it exists.
+    ///
+    /// ```
+    /// # use specs::prelude::*;
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Pos { x: i32, y: i32 } impl Component for Pos { type Storage = VecStorage<Self>; }
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Vel { x: i32, y: i32 } impl Component for Vel { type Storage = VecStorage<Self>; }
+    /// struct ExampleSystem;
+    /// impl<'a> System<'a> for ExampleSystem {
+    ///     type SystemData = (
+    ///         WriteStorage<'a, Pos>,
+    ///         ReadStorage<'a, Vel>,
+    ///     );
+    ///     fn run(&mut self, (mut positions, velocities): Self::SystemData) {
+    ///         for (mut position, maybe_velocity) in (&mut positions, velocities.maybe()).join() {
+    ///             if let Some(velocity) = maybe_velocity {
+    ///                 position.x += velocity.x;
+    ///                 position.y += velocity.y;
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     let mut world = World::new();
+    ///     let mut dispatcher = DispatcherBuilder::new()
+    ///         .with(ExampleSystem, "example_system", &[])
+    ///         .build();
+    ///
+    ///     dispatcher.setup(&mut world.res);
+    ///
+    ///     let e1 = world.create_entity()
+    ///         .with(Pos { x: 0, y: 0 })
+    ///         .with(Vel { x: 5, y: 2 })
+    ///         .build();
+    ///
+    ///     let e2 = world.create_entity()
+    ///         .with(Pos { x: 0, y: 0 })
+    ///         .build();
+    ///
+    ///     dispatcher.dispatch(&mut world.res);
+    ///
+    ///     let positions = world.read_storage::<Pos>();
+    ///     assert_eq!(positions.get(e1), Some(&Pos { x: 5, y: 2 }));
+    ///     assert_eq!(positions.get(e2), Some(&Pos { x: 0, y: 0 }));
+    /// }
+    /// ```
     fn maybe(self) -> MaybeJoin<Self>
     where
         Self: Sized,
@@ -187,6 +235,9 @@ pub unsafe trait ParJoin: Join {
     }
 }
 
+/// Optionally gets a `Join`, for usage see [`Join::maybe()`].
+///
+/// [`Join::maybe()`]: ../join/trait.Join.html#method.maybe
 pub struct MaybeJoin<J: Join>(pub J);
 
 impl<T> Join for MaybeJoin<T>
@@ -195,10 +246,10 @@ where
 {
     type Type = Option<<T as Join>::Type>;
     type Value = (<T as Join>::Mask, <T as Join>::Value);
-    type Mask = BitSetNot<BitSet>;
+    type Mask = BitSetAll;
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
         let (mask, value) = self.0.open();
-        (BitSetNot(BitSet::new()), (mask, value))
+        (BitSetAll, (mask, value))
     }
     unsafe fn get((mask, value): &mut Self::Value, id: Index) -> Self::Type {
         if mask.contains(id) {

--- a/src/join.rs
+++ b/src/join.rs
@@ -155,7 +155,13 @@ pub trait Join {
         JoinIter::new(self)
     }
 
-    /// Optionally gets a `Join` if it exists.
+    /// Returns a `Join`-able structure that yields all indices, returning `None` for all
+    /// missing elements and `Some(T)` for found elements.
+    ///
+    /// WARNING: Do not have a join of only `MaybeJoin`s. Otherwise the join will
+    /// iterate over every single index of the bitset. If you want a join with
+    /// all `MaybeJoin`s, add an `EntitiesRes` to the join as well to bound the
+    /// join to all entities that are alive.
     ///
     /// ```
     /// # use specs::prelude::*;
@@ -235,7 +241,15 @@ pub unsafe trait ParJoin: Join {
     }
 }
 
-/// Optionally gets a `Join`, for usage see [`Join::maybe()`].
+/// A `Join`-able structure that yields all indices, returning `None` for all
+/// missing elements and `Some(T)` for found elements.
+///
+/// For usage see [`Join::maybe()`].
+///
+/// WARNING: Do not have a join of only `MaybeJoin`s. Otherwise the join will
+/// iterate over every single index of the bitset. If you want a join with
+/// all `MaybeJoin`s, add an `EntitiesRes` to the join as well to bound the
+/// join to all entities that are alive.
 ///
 /// [`Join::maybe()`]: ../join/trait.Join.html#method.maybe
 pub struct MaybeJoin<J: Join>(pub J);


### PR DESCRIPTION
Related issue: https://github.com/slide-rs/specs/issues/358

Adds a generic `MaybeJoin` to all `Join` structures to optionally get a component.

I think we might want to add an `BitSetAll` BitSetLike to hibitset for a more specialized `BitSetNot(BitSet::new())` since I don't like the idea of allocation of some vecs on a join that won't actually be used. Ideally just have a BitSetLike that returns the max usize on all layers.

Dependent on https://github.com/slide-rs/hibitset/pull/36 for optimization (not sure if rust is smart enough to remove the unnecessary Vec allocations.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/455)
<!-- Reviewable:end -->
