### PR TITLE
Reduced the complexity of the entity allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ features = ["common", "serde"]
 cgmath =  { version = "0.14", features = ["eders"] }
 criterion = "0.2"
 ron = "0.2"
-rand = "0.3"
+rand = "0.5"
 serde_json = "1.0"
 specs-derive = { path = "specs-derive", version = "0.2.0" }
 


### PR DESCRIPTION
This pull request uses a vector to store deleted entities to reduce the complexity of entity allocation to O(1)*.
The maximum memory footprint is 2x the maximum current amount but it can only happen in the worst case and is I believe acceptable for such a use case.

The current approach has the pitfall of often reusing the same entities, hence potentially making their generation quite high. Introducing a VecDequeue instead of the current Vec for the EntityCache could potentially solve this problem (with a cost in memory), so if you believe the change would be worth it I can add it relatively easily. However, this might be unnecessary as 2³¹-1 is the maximum generation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/457)
<!-- Reviewable:end -->
