### PR TITLE
Saveload custom derive

### DIFF
--- a/specs-derive/Cargo.toml
+++ b/specs-derive/Cargo.toml
@@ -9,8 +9,12 @@ keywords = ["gamedev", "parallel", "specs", "ecs", "derive"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-syn = "0.12"
+syn = {version="0.12", features=["extra-traits"]}
 quote = "0.4"
+
+[dev-dependencies]
+specs = { path = "..", features=["serde"] }
+serde = "1"
 
 [lib]
 proc-macro = true

--- a/specs-derive/Cargo.toml
+++ b/specs-derive/Cargo.toml
@@ -9,11 +9,11 @@ keywords = ["gamedev", "parallel", "specs", "ecs", "derive"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-syn = {version="0.12", features=["extra-traits"]}
+syn = { version = "0.12", features = ["extra-traits"] }
 quote = "0.4"
 
 [dev-dependencies]
-specs = { path = "..", features=["serde"] }
+specs = { path = "..", features = ["serde"] }
 serde = "1"
 
 [lib]

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -169,7 +169,7 @@ fn saveload_struct(
 /// This generates a struct named `StructNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
 ///  e.g.
 ///
-/// ```
+/// ```nobuild
 /// struct FooSaveloadData<MA> where MA: Serialize+Marker, for<'de> MA: Deserialize<'de> {
 ///    e: <Entity as IntoSerialize<MA>>::Data
 /// }
@@ -178,7 +178,7 @@ fn saveload_struct(
 /// The generation for the `into` and `from` functions just constructs each field by calling `into`/`from` for each field in the input struct
 /// and placing it into the output struct:
 ///
-/// ```
+/// ```nobuild
 ///  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
 ///      FooSaveloadData {
 ///          e: IntoSerialize::into(&self.e, &mut ids)?
@@ -226,8 +226,8 @@ fn saveload_named_struct(
 /// This generates a struct named `StructNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
 ///  e.g.
 ///
-/// ```
-/// struct FooSaveloadData<MA>  (
+/// ```nobuild
+/// struct FooSaveloadData<MA> (
 ///    <Entity as IntoSerialize<MA>>::Data
 /// ) where MA: Serialize+Marker, for<'de> MA: Deserialize<'de>;
 /// ```
@@ -235,7 +235,7 @@ fn saveload_named_struct(
 /// The generation for the `into` and `from` functions just constructs each field by calling `into`/`from` for each field in the input struct
 /// and placing it into the output struct:
 ///
-/// ```
+/// ```nobuild
 ///  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
 ///      FooSaveloadData (
 ///          e: IntoSerialize::into(&self.0, &mut ids)?
@@ -290,7 +290,7 @@ fn saveload_tuple_struct(
 /// This generates a struct named `EnumNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
 ///  e.g.
 ///
-/// ```
+/// ```nobuild
 /// enum FooSaveloadData<MA> where MA: Serialize+Marker, for<'de> MA: Deserialize<'de> {
 ///    Bar(<Entity as IntoSerialize<MA>>::Data),
 ///    Baz { e: <Entity as IntoSerialize<MA>>::Data },
@@ -301,7 +301,7 @@ fn saveload_tuple_struct(
 /// The generation for the `into` and `from` functions just constructs each field of each variant by calling `into`/`from` for each field in the input
 /// and placing it into the output struct in a giant match of each possibility:
 ///
-/// ```
+/// ```nobuild
 ///  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
 ///      match *self {
 ///          Foo::Bar(ref field0) => FooSaveloadData::Bar(IntoSerialize::into(field0, &mut ids)? ),

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -1,0 +1,496 @@
+//! Contains implementations for #[derive(Saveload)]
+//! which derives both `IntoSerialize` and `FromDeserialize`.
+//!
+//! Since this requires a proxy "Data" `struct`/`enum`, these two need
+//! to be derived together or it begins requiring unwieldy attribute explosion.
+//!
+//! Currently there is one major limitation to this implementation: it cannot handle
+//! generic types such as `struct Foo<T> { x: T, e: Entity }`. I'm not good enough at
+//! using `syn` to iron this out, but since specs requires explicit references to non-generic
+//! components in system data, it can generally be worked around by newtyping like
+//! `struct TypedFoo(Foo<u32>);` and the like.
+
+// NOTE: All examples given in the documentation below are "cleaned up" into readable Rust,
+// so it doesn't give an entirely accurate view of what's actually generated (for instance,
+// I'll write `Entity` instead of `::specs::Entity` which is actually what's generated).
+
+use quote::Tokens;
+use syn::{DataEnum, DataStruct, DeriveInput, Field, Generics, Ident, Type, TypeParamBound};
+
+// Handy collection since tuples got unwieldy and
+// unclear in purpose
+struct SaveloadDerive {
+    type_def: Tokens,
+    ser: Tokens,
+    de: Tokens,
+    saveload_name: Ident,
+    saveload_generics: Generics,
+}
+
+/// The main entrypoint, sets things up and delegates to the
+/// type we're deriving on.
+pub fn impl_saveload(ast: &mut DeriveInput) -> Tokens {
+    use syn::Data;
+
+    if !ast.generics.params.is_empty() {
+        panic!("Deriving `Saveload` does not, at the moment, support generic types (i.e. `struct Foo<T>`).
+        
+        This limitation may be fixed in the future, but for now you can usually work around this by newtyping
+        your generic data structure to a concrete-variant (e.g. `struct FooU32(Foo<u32>);`), or implementing `IntoSerialize` and `FromDeserialize` 
+        yourself, which is relatively straightforward if tedious (see the documentation for those traits).")
+    }
+
+    add_bound(
+        &mut ast.generics,
+        parse_quote!(::specs::saveload::IntoSerialize),
+    );
+    add_bound(
+        &mut ast.generics,
+        parse_quote!(::specs::saveload::FromDeserialize),
+    );
+    add_bound(&mut ast.generics, parse_quote!(Clone));
+
+    let derive = match ast.data {
+        Data::Struct(ref mut data) => saveload_struct(data, &mut ast.ident, &mut ast.generics),
+        Data::Enum(ref data) => saveload_enum(data, &ast.ident, &ast.generics),
+        Data::Union(_) => panic!("Unions cannot derive IntoSerialize/FromDeserialize at present"),
+    };
+
+    let name = ast.ident;
+
+    let mut impl_generics = ast.generics.clone();
+    impl_generics.params.push(parse_quote!(
+        MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker
+    ));
+    let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
+    let (_, ty_generics, _) = ast.generics.split_for_impl(); // We don't want the type generics we just made
+                                                             // because they have MA which our normal type doesn't have
+
+    let type_def = derive.type_def;
+    let saveload_name = derive.saveload_name;
+    let saveload_generics = derive.saveload_generics;
+
+    let ser = derive.ser;
+    let de = derive.de;
+
+    let tt = quote!{
+        #[derive(Serialize, Deserialize, Clone)]
+        #[serde(bound = "MA: ::specs::saveload::Marker")]
+        #type_def
+
+        impl #impl_generics ::specs::saveload::IntoSerialize<MA> for #name #ty_generics #where_clause {
+            type Data = #saveload_name #saveload_generics;
+            type Error = ::specs::error::NoError;
+
+            fn into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+            where
+                F: FnMut(::specs::Entity) -> Option<MA>
+            {
+                #ser
+            }
+        }
+
+        impl #impl_generics ::specs::saveload::FromDeserialize<MA> for #name #ty_generics #where_clause {
+            type Data = #saveload_name #saveload_generics;
+            type Error = ::specs::error::NoError;
+
+            fn from<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+            where
+                F: FnMut(MA) -> Option<Entity>
+            {
+                #de
+            }
+        }
+    };
+
+    // panic!("{}", tt);
+
+    tt
+}
+
+// Implements all elements of saveload common to structs of any type
+// (except unit structs like `struct Foo;` since they're auto-saveload);
+fn saveload_struct(
+    data: &mut DataStruct,
+    name: &mut Ident,
+    generics: &mut Generics,
+) -> SaveloadDerive {
+    use syn::Fields;
+
+    let mut saveload_generics = generics.clone();
+    saveload_generics.params.push(parse_quote!(MA));
+    match saveload_generics.where_clause {
+        Some(ref mut clause) => clause.predicates.push(parse_quote!(
+            MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        )),
+        ref mut clause @ None => {
+            *clause = Some(parse_quote!(
+            where MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        ))
+        }
+    }
+
+    let saveload_name = Ident::new(&format!("{}SaveloadData", name), name.span);
+
+    let saveload_fields: Vec<_> = data
+        .fields
+        .iter()
+        .cloned()
+        .map(|mut f| {
+            replace_entity_type(&mut f.ty);
+            f
+        })
+        .collect();
+
+    let (struct_def, ser, de) = if let Fields::Named(_) = data.fields {
+        saveload_named_struct(&name, &saveload_name, &saveload_generics, &saveload_fields)
+    } else if let Fields::Unnamed(_) = data.fields {
+        saveload_tuple_struct(
+            &data,
+            &name,
+            &saveload_name,
+            &saveload_generics,
+            &saveload_fields,
+        )
+    } else {
+        panic!("This derive does not support unit structs (Hint: they automatically derive FromDeserialize and IntoSerialize)");
+    };
+
+    SaveloadDerive {
+        type_def: struct_def,
+        ser,
+        de,
+        saveload_name,
+        saveload_generics,
+    }
+}
+
+// Automatically derives the two traits and proxy `Data` container for a struct with named fields (e.g. `struct Foo {e: Entity}`).
+//
+// This generates a struct named `StructNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
+//  e.g.
+//
+// ```
+// struct FooSaveloadData<MA> where MA: Serialize+Marker, for<'de> MA: Deserialize<'de> {
+//    e: <Entity as IntoSerialize<MA>>::Data
+// }
+// ```
+//
+// The generation for the `into` and `from` functions just constructs each field by calling `into`/`from` for each field in the input struct
+// and placing it into the output struct:
+//
+// ```
+//  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
+//      FooSaveloadData {
+//          e: IntoSerialize::into(&self.e, &mut ids)?
+//      }
+//  }
+// ```
+//
+// And similar for `FromDeserialize`.
+fn saveload_named_struct(
+    name: &Ident,
+    saveload_name: &Ident,
+    generics: &Generics,
+    saveload_fields: &[Field],
+) -> (Tokens, Tokens, Tokens) {
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let struct_def = quote!{
+        struct #saveload_name #ty_generics #where_clause {
+            #( #saveload_fields ),*
+        }
+    };
+
+    let field_names = saveload_fields.iter().map(|f| f.ident.clone());
+    let field_names_2 = field_names.clone();
+    let ser = quote!{
+        Ok(#saveload_name {
+                # ( #field_names: ::specs::saveload::IntoSerialize::into(&self.#field_names_2, &mut ids)? ),*
+            })
+    };
+
+    let field_names = saveload_fields.iter().map(|f| f.ident.clone());
+    let field_names_2 = field_names.clone();
+    let de = quote! { Ok(#name {
+                # ( #field_names: ::specs::saveload::FromDeserialize::from(data.#field_names_2, &mut ids)? ),*
+            })
+    };
+
+    (struct_def, ser, de)
+}
+
+// Automatically derives the two traits and proxy `Data` container for a struct with unnamed fields aka a tuple struct (e.g. `struct Foo(Entity);`).
+//
+// This generates a struct named `StructNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
+//  e.g.
+//
+// ```
+// struct FooSaveloadData<MA>  (
+//    <Entity as IntoSerialize<MA>>::Data
+// ) where MA: Serialize+Marker, for<'de> MA: Deserialize<'de>;
+// ```
+//
+// The generation for the `into` and `from` functions just constructs each field by calling `into`/`from` for each field in the input struct
+// and placing it into the output struct:
+//
+// ```
+//  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
+//      FooSaveloadData (
+//          e: IntoSerialize::into(&self.0, &mut ids)?
+//      )
+//  }
+// ```
+//
+// And similar for `FromDeserialize`.
+fn saveload_tuple_struct(
+    data: &DataStruct,
+    name: &Ident,
+    saveload_name: &Ident,
+    generics: &Generics,
+    saveload_fields: &[Field],
+) -> (Tokens, Tokens, Tokens) {
+    use syn::Index;
+
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let struct_def = quote!{
+        struct #saveload_name #ty_generics (
+            #( #saveload_fields ),*
+        ) #where_clause;
+    };
+
+    let field_ids = saveload_fields.iter().enumerate().map(|(i, _)| Index {
+        index: i as u32,
+        span: data.struct_token.0.clone(),
+    });
+    let ser = quote!{
+        Ok(#saveload_name (
+                # ( ::specs::saveload::IntoSerialize::into(&self.#field_ids, &mut ids)? ),*
+            ))
+    };
+
+    let field_ids = saveload_fields.iter().enumerate().map(|(i, _)| Index {
+        index: i as u32,
+        span: data.struct_token.0.clone(),
+    });
+    let de = quote! { Ok(#name (
+                # ( ::specs::saveload::FromDeserialize::from(data.#field_ids, &mut ids)? ),*
+            ))
+    };
+
+    (struct_def, ser, de)
+}
+
+// Automatically derives the two traits and proxy `Data` container for an Enum (e.g. `enum Foo{ Bar(Entity), Baz{ e: Entity }, Unit }`).
+//
+// This will properly handle enum variants with no `Entity`, so long as at least one variant (or one of that variant's fields recursively) contain an
+// `Entity` somewhere. If this isn't true, `Saveload` is auto-derived so long as the fields can be `Serialize` and `Deserialize` anyway.
+//
+// This generates a struct named `EnumNameSaveloadData` such that all fields are their associated `Data` variants, as well as a bound on the required marker
+//  e.g.
+//
+// ```
+// enum FooSaveloadData<MA> where MA: Serialize+Marker, for<'de> MA: Deserialize<'de> {
+//    Bar(<Entity as IntoSerialize<MA>>::Data),
+//    Baz { e: <Entity as IntoSerialize<MA>>::Data },
+//    Unit
+// };
+// ```
+//
+// The generation for the `into` and `from` functions just constructs each field of each variant by calling `into`/`from` for each field in the input
+// and placing it into the output struct in a giant match of each possibility:
+//
+// ```
+//  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
+//      match *self {
+//          Foo::Bar(ref field0) => FooSaveloadData::Bar(IntoSerialize::into(field0, &mut ids)? ),
+//          Foo::Baz{ ref e } => FooSaveloadData::Baz{ e: IntoSerialize::into(e, &mut ids)? },
+//          Foo::Unit => FooSaveloadData::Unit,
+//      }
+//  }
+// ```
+//
+// And similar for `FromDeserialize`.
+fn saveload_enum(data: &DataEnum, name: &Ident, generics: &Generics) -> SaveloadDerive {
+    use syn::Fields;
+
+    let mut saveload_generics = generics.clone();
+    saveload_generics.params.push(parse_quote!(MA));
+
+    match saveload_generics.where_clause {
+        Some(ref mut clause) => clause.predicates.push(parse_quote!(
+            MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        )),
+        ref mut clause @ None => {
+            *clause = Some(parse_quote!(
+            where MA: ::serde::Serialize + ::serde::de::DeserializeOwned + ::specs::saveload::Marker,
+            for <'deser> MA: ::serde::Deserialize<'deser>
+        ))
+        }
+    }
+
+    let saveload_name = Ident::new(&format!("{}SaveloadData", name), name.span);
+
+    let mut saveload = data.clone();
+
+    for variant in saveload.variants.iter_mut() {
+        if let Fields::Unnamed(ref mut fields) = variant.fields {
+            for f in fields.unnamed.iter_mut() {
+                replace_entity_type(&mut f.ty);
+            }
+        } else if let Fields::Named(ref mut fields) = variant.fields {
+            for f in fields.named.iter_mut() {
+                replace_entity_type(&mut f.ty);
+            }
+        }
+    }
+
+    let variants = &saveload.variants;
+
+    let (_, saveload_ty_generics, saveload_where_clause) = saveload_generics.split_for_impl();
+    let enum_def = quote!{
+        enum #saveload_name #saveload_ty_generics #saveload_where_clause {
+            #( #variants ),*
+        }
+    };
+
+    let mut big_match_ser = quote!{};
+    let mut big_match_de = quote!{};
+
+    for variant in variants {
+        let ident = &variant.ident;
+
+        match variant.fields {
+            Fields::Named(ref fields) => {
+                let names = fields.named.iter().map(|f| f.ident);
+                let names_2 = fields.named.iter().map(|f| f.ident);
+                let names_3 = fields.named.iter().map(|f| f.ident);
+
+                big_match_ser = quote!{
+                    #big_match_ser
+                    #name::#ident { #( ref #names ),* } => #saveload_name::#ident { #( #names_3: ::specs::saveload::IntoSerialize::into(#names_2, ids)? ),* },
+                };
+
+                let names = fields.named.iter().map(|f| f.ident);
+                let names_2 = fields.named.iter().map(|f| f.ident);
+                let names_3 = fields.named.iter().map(|f| f.ident);
+
+                big_match_de = quote!{
+                    #big_match_de
+                    #saveload_name::#ident { #( #names ),* } => #name::#ident { #( #names_3: ::specs::saveload::FromDeserialize::from(#names_2, &mut ids)? ),* },
+                };
+            }
+            Fields::Unnamed(ref fields) => {
+                let field_ids: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(i, _)| Some(Ident::new(&format!("field{}", i), data.enum_token.0)))
+                    .collect();
+
+                let field_ids_2 = field_ids.clone();
+
+                big_match_ser = quote!{
+                    #big_match_ser
+                    #name::#ident( #( ref #field_ids ),* ) => #saveload_name::#ident( #( ::specs::saveload::IntoSerialize::into(#field_ids_2, &mut ids)? ),* ),
+                };
+
+                let field_ids: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(i, _)| Some(Ident::new(&format!("field{}", i), data.enum_token.0)))
+                    .collect();
+
+                let field_ids_2 = field_ids.clone();
+
+                big_match_de = quote!{
+                    #big_match_de
+                    #saveload_name::#ident( #( #field_ids ),* ) => #name::#ident( #( ::specs::saveload::FromDeserialize::from(#field_ids_2, &mut ids)? ),* ),
+                };
+            }
+            Fields::Unit => {
+                big_match_ser = quote! {
+                    #big_match_ser
+                    #name::#ident => #saveload_name::#ident,
+                };
+
+                big_match_de = quote! {
+                    #big_match_de
+                    #saveload_name::#ident => #name::#ident,
+                };
+            }
+        }
+    }
+
+    let ser = quote!{
+        Ok(match *self {
+            #big_match_ser
+        })
+    };
+
+    let de = quote!{
+        Ok(match data {
+            #big_match_de
+        })
+    };
+
+    SaveloadDerive {
+        type_def: enum_def,
+        ser,
+        de,
+        saveload_name,
+        saveload_generics: saveload_generics.clone(), // dumb borrow checker, don't feel like fixing because it's probably NBD
+    }
+}
+
+// Edits the bounds of the input type to ensure all fields have `bound`.
+fn add_bound(generics: &mut Generics, bound: TypeParamBound) {
+    use syn::GenericParam;
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            if type_param.bounds.iter().position(|b| bound == *b).is_some() {
+                continue;
+            }
+            type_param.bounds.push(bound.clone());
+        }
+    }
+}
+
+// Replaces the type with its corresponding `Data` type.
+fn replace_entity_type(ty: &mut Type) {
+    match *ty {
+        Type::Array(ref mut ty) => replace_entity_type(&mut *ty.elem),
+        Type::Tuple(ref mut ty) => {
+            for ty in ty.elems.iter_mut() {
+                replace_entity_type(&mut *ty);
+            }
+        }
+        Type::Paren(ref mut ty) => replace_entity_type(&mut *ty.elem),
+        Type::Path(ref mut ty) => {
+            let ty_tok = ty.clone();
+            *ty = parse_quote!(<#ty_tok as ::specs::saveload::IntoSerialize<MA>>::Data);
+        }
+        Type::Group(ref mut ty) => replace_entity_type(&mut *ty.elem),
+
+        Type::TraitObject(_) => {}
+        Type::ImplTrait(_) => {}
+        Type::Slice(_) => {
+            panic!("Slices are unsupported, use owned types like Vecs or Arrays instead")
+        }
+        Type::Reference(_) => panic!("References are unsupported"),
+        Type::Ptr(_) => panic!("Raw pointer types are unsupported"),
+        Type::BareFn(_) => panic!("Function types are unsupported"),
+        /* We're in a struct so it doesn't matter */
+        Type::Never(_) => unreachable!(),
+        Type::Infer(_) => unreachable!(),
+        Type::Macro(_) => unreachable!(),
+        Type::Verbatim(_) => unimplemented!(),
+    }
+}

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -76,7 +76,7 @@ pub fn impl_saveload(ast: &mut DeriveInput) -> Tokens {
     let tt = quote!{
         #[derive(Serialize, Deserialize, Clone)]
         #[serde(bound = "MA: ::specs::saveload::Marker")]
-        #type_def
+        pub #type_def
 
         impl #impl_generics ::specs::saveload::IntoSerialize<MA> for #name #ty_generics #where_clause {
             type Data = #saveload_name #saveload_generics;

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -1,14 +1,5 @@
 //! Contains implementations for `#[derive(Saveload)]`
 //! which derives `ConvertSaveload`.
-//!
-//! Since this requires a proxy "Data" `struct`/`enum`, these two need
-//! to be derived together or it begins requiring unwieldy attribute explosion.
-//!
-//! Currently there is one major limitation to this implementation: it cannot handle
-//! generic types such as `struct Foo<T> { x: T, e: Entity }`. I'm not good enough at
-//! using `syn` to iron this out, but since specs requires explicit references to non-generic
-//! components in system data, it can generally be worked around by newtyping like
-//! `struct TypedFoo(Foo<u32>);` and the like.
 
 // NOTE: All examples given in the documentation below are "cleaned up" into readable Rust,
 // so it doesn't give an entirely accurate view of what's actually generated (for instance,
@@ -58,7 +49,7 @@ pub fn impl_saveload(ast: &mut DeriveInput) -> Tokens {
     let derive = match ast.data {
         Data::Struct(ref mut data) => saveload_struct(data, &mut ast.ident, &mut ast.generics),
         Data::Enum(ref data) => saveload_enum(data, &ast.ident, &ast.generics),
-        Data::Union(_) => panic!("Unions cannot derive `ConvertSaveload`/`ConvertSaveload`"),
+        Data::Union(_) => panic!("Unions cannot derive `ConvertSaveload`"),
     };
 
     let name = ast.ident;

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -238,7 +238,7 @@ fn saveload_named_struct(
 /// ```nobuild
 ///  fn into<F: FnMut(Entity) -> Option<MA>>(&self, mut ids: F) -> Result<Self::Data, Self::Error> {
 ///      FooSaveloadData (
-///          e: IntoSerialize::into(&self.0, &mut ids)?
+///          IntoSerialize::into(&self.0, &mut ids)?
 ///      )
 ///  }
 /// ```

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -1,4 +1,4 @@
-//! Implements the `#[derive(Component)]` macro and `#[component]` attribute for
+//! Implements the `#[derive(Component)]`, `#[derive(Saveload)]` macro and `#[component]` attribute for
 //! [Specs][sp].
 //!
 //! [sp]: https://slide-rs.github.io/specs-website/

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -69,6 +69,18 @@ fn impl_component(ast: &DeriveInput) -> Tokens {
     }
 }
 
+/// Custom derive macro for the `ConvertSaveload` trait.
+/// 
+/// Requires `Entity`, `ConvertSaveload`, `Marker` and `NoError` to be in a scope.
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// use specs::{Entity, saveload::{ConvertSaveload, Marker}, error::NoError};
+/// 
+/// #[derive(ConvertSaveload)]
+/// struct Target(Entity);
+/// ```
 #[proc_macro_derive(ConvertSaveload)]
 pub fn saveload(input: TokenStream) -> TokenStream {
     use impl_saveload::impl_saveload;

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -69,7 +69,7 @@ fn impl_component(ast: &DeriveInput) -> Tokens {
     }
 }
 
-#[proc_macro_derive(Saveload)]
+#[proc_macro_derive(ConvertSaveload)]
 pub fn saveload(input: TokenStream) -> TokenStream {
     use impl_saveload::impl_saveload;
     let mut ast = syn::parse(input).unwrap();

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -1,6 +1,3 @@
-// These are mostly just compile tests
-#![allow(dead_code)]
-
 #[macro_use]
 extern crate serde;
 extern crate specs;
@@ -53,9 +50,7 @@ mod tests {
     use specs::{Builder, World};
     use specs::saveload::{ConvertSaveload, U64Marker};
 
-    /* Just a compile test to verify that we meet the proper bounds.
-    Does not need to be #[test] since it's a compile test */
-
+    #[test]
     fn type_check() {
         let mut world = World::new();
         let entity = world.create_entity().build();

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -7,65 +7,72 @@ extern crate specs;
 #[macro_use]
 extern crate specs_derive;
 
-// #[derive(Saveload)]
-// struct OneFieldNamed {
-//     e: Entity,
-// }
+#[derive(ConvertSaveload)]
+struct OneFieldNamed {
+    e: ::specs::Entity,
+}
 
-// #[derive(Saveload)]
-// struct TwoField {
-//     a: u32,
-//     e: Entity,
-// }
+#[derive(ConvertSaveload)]
+struct TwoField {
+    a: u32,
+    e: ::specs::Entity,
+}
 
-// // Tests a struct that owns a parent
-// // that derives Saveload
-// #[derive(Saveload)]
-// struct LevelTwo {
-//     owner: OneFieldNamed,
-// }
+// Tests a struct that owns a parent
+// that derives Saveload
+#[derive(ConvertSaveload)]
+struct LevelTwo {
+    owner: OneFieldNamed,
+}
 
-// #[derive(Saveload)]
-// struct OneFieldTuple(Entity);
+#[derive(ConvertSaveload)]
+struct OneFieldTuple(::specs::Entity);
 
-// #[derive(Saveload)]
-// struct TwoFieldTuple(Entity, u32);
+#[derive(ConvertSaveload)]
+struct TwoFieldTuple(::specs::Entity, u32);
 
-// #[derive(Saveload)]
-// struct LevelTwoTuple(OneFieldNamed);
+#[derive(ConvertSaveload)]
+struct LevelTwoTuple(OneFieldNamed);
 
-// #[derive(Saveload)]
-// enum AnEnum {
-//     E(Entity),
-//     F { e: Entity },
-//     Unit,
-// }
+#[derive(ConvertSaveload)]
+enum AnEnum {
+    E(::specs::Entity),
+    F { e: ::specs::Entity },
+    Unit,
+}
 
-#[derive(Saveload)]
-struct Generic<E>(E);
+#[derive(ConvertSaveload)]
+struct Generic<E: EntityLike>(E);
 
-// mod tests {
-//     use super::*;
-//     use specs::saveload::{FromDeserialize, IntoSerialize, U64Marker};
+trait EntityLike {}
 
-//     /* Just a compile test to verify that we meet the proper bounds.
-//     Does not need to be #[test] since it's a compile test */
+impl EntityLike for ::specs::Entity {}
 
-//     fn type_check() {
-//         let mut world = World::new();
-//         let entity = world.create_entity().build();
+mod tests {
+    use super::*;
+    use specs::{Builder, World};
+    use specs::saveload::{ConvertSaveload, U64Marker};
 
-//         black_box::<U64Marker, _>(OneFieldNamed { e: entity });
-//         black_box::<U64Marker, _>(TwoField { a: 5, e: entity });
-//         black_box::<U64Marker, _>(LevelTwo {
-//             owner: OneFieldNamed { e: entity },
-//         });
-//         black_box::<U64Marker, _>(OneFieldTuple(entity));
-//         black_box::<U64Marker, _>(TwoFieldTuple(entity, 5));
-//         // The derive will work for all variants
-//         // so no need to test anything but unit
-//         black_box::<U64Marker, _>(AnEnum::Unit);
-//     }
+    /* Just a compile test to verify that we meet the proper bounds.
+    Does not need to be #[test] since it's a compile test */
 
-//     fn black_box<M, T: IntoSerialize<M> + FromDeserialize<M>>(_item: T) {}
-// }
+    fn type_check() {
+        let mut world = World::new();
+        let entity = world.create_entity().build();
+
+        black_box::<U64Marker, _>(OneFieldNamed { e: entity });
+        black_box::<U64Marker, _>(TwoField { a: 5, e: entity });
+        black_box::<U64Marker, _>(LevelTwo {
+            owner: OneFieldNamed { e: entity },
+        });
+        black_box::<U64Marker, _>(OneFieldTuple(entity));
+        black_box::<U64Marker, _>(TwoFieldTuple(entity, 5));
+        // The derive will work for all variants
+        // so no need to test anything but unit
+        black_box::<U64Marker, _>(AnEnum::Unit);
+        
+        black_box::<U64Marker, _>(Generic(entity));
+    }
+
+    fn black_box<M, T: ConvertSaveload<M>>(_item: T) {}
+}

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -1,0 +1,70 @@
+// These are mostly just compile tests
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate serde;
+extern crate specs;
+#[macro_use]
+extern crate specs_derive;
+
+use specs::prelude::*;
+
+#[derive(Saveload)]
+struct OneFieldNamed {
+    e: Entity,
+}
+
+#[derive(Saveload)]
+struct TwoField {
+    a: u32,
+    e: Entity,
+}
+
+// Tests a struct that owns a parent
+// that derives Saveload
+#[derive(Saveload)]
+struct LevelTwo {
+    owner: OneFieldNamed,
+}
+
+#[derive(Saveload)]
+struct OneFieldTuple(Entity);
+
+#[derive(Saveload)]
+struct TwoFieldTuple(Entity, u32);
+
+#[derive(Saveload)]
+struct LevelTwoTuple(OneFieldNamed);
+
+#[derive(Saveload)]
+enum AnEnum {
+    E(Entity),
+    F { e: Entity },
+    Unit,
+}
+
+mod tests {
+    use super::*;
+    use specs::saveload::{FromDeserialize, IntoSerialize, U64Marker};
+
+    /* Just a compile test to verify that we meet the proper bounds.
+    Does not need to be #[test] since it's a compile test */
+
+    fn type_check() {
+        let mut world = World::new();
+        let entity = world.create_entity().build();
+
+        black_box::<U64Marker, _>(OneFieldNamed { e: entity });
+        black_box::<U64Marker, _>(TwoField { a: 5, e: entity });
+        black_box::<U64Marker, _>(LevelTwo {
+            owner: OneFieldNamed { e: entity },
+        });
+        black_box::<U64Marker, _>(OneFieldTuple(entity));
+        black_box::<U64Marker, _>(TwoFieldTuple(entity, 5));
+        // The derive will work for all variants
+        // so no need to test anything but unit
+        black_box::<U64Marker, _>(AnEnum::Unit);
+    }
+
+    fn black_box<M, T: IntoSerialize<M> + FromDeserialize<M>>(_item: T) {}
+}

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -1,18 +1,21 @@
 #[macro_use]
 extern crate serde;
-extern crate specs;
+// Specs is renamed here so that the custom derive cannot refer specs directly
+extern crate specs as spocs;
 #[macro_use]
 extern crate specs_derive;
 
+use spocs::{Entity, saveload::{ConvertSaveload, Marker}, error::NoError};
+
 #[derive(ConvertSaveload)]
 struct OneFieldNamed {
-    e: ::specs::Entity,
+    e: Entity,
 }
 
 #[derive(ConvertSaveload)]
 struct TwoField {
     a: u32,
-    e: ::specs::Entity,
+    e: Entity,
 }
 
 // Tests a struct that owns a parent
@@ -23,18 +26,18 @@ struct LevelTwo {
 }
 
 #[derive(ConvertSaveload)]
-struct OneFieldTuple(::specs::Entity);
+struct OneFieldTuple(Entity);
 
 #[derive(ConvertSaveload)]
-struct TwoFieldTuple(::specs::Entity, u32);
+struct TwoFieldTuple(Entity, u32);
 
 #[derive(ConvertSaveload)]
 struct LevelTwoTuple(OneFieldNamed);
 
 #[derive(ConvertSaveload)]
 enum AnEnum {
-    E(::specs::Entity),
-    F { e: ::specs::Entity },
+    E(Entity),
+    F { e: Entity },
     Unit,
 }
 
@@ -43,12 +46,12 @@ struct Generic<E: EntityLike>(E);
 
 trait EntityLike {}
 
-impl EntityLike for ::specs::Entity {}
+impl EntityLike for Entity {}
 
 mod tests {
     use super::*;
-    use specs::{Builder, World};
-    use specs::saveload::{ConvertSaveload, U64Marker};
+    use spocs::{Builder, World};
+    use spocs::saveload::{ConvertSaveload, U64Marker};
 
     #[test]
     fn type_check() {

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -7,64 +7,65 @@ extern crate specs;
 #[macro_use]
 extern crate specs_derive;
 
-use specs::prelude::*;
+// #[derive(Saveload)]
+// struct OneFieldNamed {
+//     e: Entity,
+// }
+
+// #[derive(Saveload)]
+// struct TwoField {
+//     a: u32,
+//     e: Entity,
+// }
+
+// // Tests a struct that owns a parent
+// // that derives Saveload
+// #[derive(Saveload)]
+// struct LevelTwo {
+//     owner: OneFieldNamed,
+// }
+
+// #[derive(Saveload)]
+// struct OneFieldTuple(Entity);
+
+// #[derive(Saveload)]
+// struct TwoFieldTuple(Entity, u32);
+
+// #[derive(Saveload)]
+// struct LevelTwoTuple(OneFieldNamed);
+
+// #[derive(Saveload)]
+// enum AnEnum {
+//     E(Entity),
+//     F { e: Entity },
+//     Unit,
+// }
 
 #[derive(Saveload)]
-struct OneFieldNamed {
-    e: Entity,
-}
+struct Generic<E>(E);
 
-#[derive(Saveload)]
-struct TwoField {
-    a: u32,
-    e: Entity,
-}
+// mod tests {
+//     use super::*;
+//     use specs::saveload::{FromDeserialize, IntoSerialize, U64Marker};
 
-// Tests a struct that owns a parent
-// that derives Saveload
-#[derive(Saveload)]
-struct LevelTwo {
-    owner: OneFieldNamed,
-}
+//     /* Just a compile test to verify that we meet the proper bounds.
+//     Does not need to be #[test] since it's a compile test */
 
-#[derive(Saveload)]
-struct OneFieldTuple(Entity);
+//     fn type_check() {
+//         let mut world = World::new();
+//         let entity = world.create_entity().build();
 
-#[derive(Saveload)]
-struct TwoFieldTuple(Entity, u32);
+//         black_box::<U64Marker, _>(OneFieldNamed { e: entity });
+//         black_box::<U64Marker, _>(TwoField { a: 5, e: entity });
+//         black_box::<U64Marker, _>(LevelTwo {
+//             owner: OneFieldNamed { e: entity },
+//         });
+//         black_box::<U64Marker, _>(OneFieldTuple(entity));
+//         black_box::<U64Marker, _>(TwoFieldTuple(entity, 5));
+//         // The derive will work for all variants
+//         // so no need to test anything but unit
+//         black_box::<U64Marker, _>(AnEnum::Unit);
+//     }
 
-#[derive(Saveload)]
-struct LevelTwoTuple(OneFieldNamed);
-
-#[derive(Saveload)]
-enum AnEnum {
-    E(Entity),
-    F { e: Entity },
-    Unit,
-}
-
-mod tests {
-    use super::*;
-    use specs::saveload::{FromDeserialize, IntoSerialize, U64Marker};
-
-    /* Just a compile test to verify that we meet the proper bounds.
-    Does not need to be #[test] since it's a compile test */
-
-    fn type_check() {
-        let mut world = World::new();
-        let entity = world.create_entity().build();
-
-        black_box::<U64Marker, _>(OneFieldNamed { e: entity });
-        black_box::<U64Marker, _>(TwoField { a: 5, e: entity });
-        black_box::<U64Marker, _>(LevelTwo {
-            owner: OneFieldNamed { e: entity },
-        });
-        black_box::<U64Marker, _>(OneFieldTuple(entity));
-        black_box::<U64Marker, _>(TwoFieldTuple(entity, 5));
-        // The derive will work for all variants
-        // so no need to test anything but unit
-        black_box::<U64Marker, _>(AnEnum::Unit);
-    }
-
-    fn black_box<M, T: IntoSerialize<M> + FromDeserialize<M>>(_item: T) {}
-}
+//     fn black_box<M, T: IntoSerialize<M> + FromDeserialize<M>>(_item: T) {}
+// }

--- a/specs-derive/tests/saveload.rs
+++ b/specs-derive/tests/saveload.rs
@@ -65,7 +65,6 @@ mod tests {
         // The derive will work for all variants
         // so no need to test anything but unit
         black_box::<U64Marker, _>(AnEnum::Unit);
-        
         black_box::<U64Marker, _>(Generic(entity));
     }
 

--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -138,7 +138,7 @@ macro_rules! deserialize_components {
             M: Marker,
             $(
                 $sto: GenericWriteStorage,
-                <$sto as GenericWriteStorage>::Component: ConvertSaveload<M>+Component,
+                <$sto as GenericWriteStorage>::Component: ConvertSaveload<M> + Component,
                 E: From<<
                     <$sto as GenericWriteStorage>::Component as ConvertSaveload<M>
                 >::Error>,

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -55,22 +55,21 @@ pub struct EntityData<M, D> {
 /// [`Clone`], [`Serialize`] and [`DeserializeOwned`].
 ///
 /// Implementing this yourself is usually only needed if you
-/// have a component that points to another Entity, or has a field which does,
+/// have a component that points to another [`Entity`], or has a field which does,
 ///  and you wish to [`Serialize`] it.
 ///
 /// *Note*: if you're using `specs_derive`
-/// and your struct does not have a generic bound (i.e. `struct Foo<T>`),
-/// you can use `#[derive(Saveload)]` to automatically derive this and
-/// [`FromDeserialize`]. You can get around generic type bounds by exploiting
-/// the newtype pattern (e.g. `struct FooU32(Foo<u32>);`).
+/// you can use `#[derive(Saveload)]` to automatically derive this.
 ///
 /// You must add the `derive` to any type that your component holds which does
-/// not auto-implement these two traits, including the component itself (similar to how
+/// not auto-implement this traits, including the component itself (similar to how
 /// normal [`Serialize`] and [`Deserialize`] work).
 ///
 /// [`Component`]: ../trait.Component.html
+/// [`Entity`]: ../struct.Entity.html
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
 /// [`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
+/// [`DeserializeOwned`]: https://docs.serde.rs/serde/de/trait.DeserializeOwned.html
 ///
 /// # Example
 ///

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -23,15 +23,20 @@
 //! see the docs for the `Marker` trait.
 //!
 
+use serde::{Serialize, de::DeserializeOwned};
+
+use error::NoError;
+use world::Entity;
+
 mod de;
 mod marker;
 mod ser;
 #[cfg(test)]
 mod tests;
 
-pub use self::de::{DeserializeComponents, FromDeserialize};
+pub use self::de::{DeserializeComponents};
 pub use self::marker::{MarkedBuilder, Marker, MarkerAllocator, U64Marker, U64MarkerAllocator};
-pub use self::ser::{IntoSerialize, SerializeComponents};
+pub use self::ser::{SerializeComponents};
 
 /// A struct used for deserializing entity data.
 #[derive(Serialize, Deserialize)]
@@ -40,4 +45,141 @@ pub struct EntityData<M, D> {
     pub marker: M,
     /// The components associated with an entity.
     pub components: D,
+}
+
+
+/// Converts a data type (usually a [`Component`]) into its serializable form
+/// and back to actual data from it's deserialized form.
+///
+/// This is automatically implemented for any type that is
+/// [`Clone`], [`Serialize`] and [`DeserializeOwned`].
+///
+/// Implementing this yourself is usually only needed if you
+/// have a component that points to another Entity, or has a field which does,
+///  and you wish to [`Serialize`] it.
+///
+/// *Note*: if you're using `specs_derive`
+/// and your struct does not have a generic bound (i.e. `struct Foo<T>`),
+/// you can use `#[derive(Saveload)]` to automatically derive this and
+/// [`FromDeserialize`]. You can get around generic type bounds by exploiting
+/// the newtype pattern (e.g. `struct FooU32(Foo<u32>);`).
+///
+/// You must add the `derive` to any type that your component holds which does
+/// not auto-implement these two traits, including the component itself (similar to how
+/// normal [`Serialize`] and [`Deserialize`] work).
+///
+/// [`Component`]: ../trait.Component.html
+/// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
+/// [`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
+///
+/// # Example
+///
+/// ```rust
+/// # extern crate specs;
+/// # #[macro_use] extern crate serde;
+/// use serde::{Serialize, Deserialize};
+/// use specs::prelude::*;
+/// use specs::error::NoError;
+/// use specs::saveload::{Marker, ConvertSaveload};
+///
+/// struct Target(Entity);
+///
+/// impl Component for Target {
+///     type Storage = VecStorage<Self>;
+/// }
+///
+/// // We need a matching "data" struct to hold our
+/// // marker. In general, you just need a single struct
+/// // per component you want to make `Serialize`/`Deserialize` with each
+/// // instance of `Entity` replaced with a generic "M".
+/// #[derive(Serialize, Deserialize)]
+/// struct TargetData<M>(M);
+///
+/// impl<M: Marker + Serialize> ConvertSaveload<M> for Target
+///     where for<'de> M: Deserialize<'de>,
+/// {
+///     type Data = TargetData<M>;
+///     type Error = NoError;
+///
+///     fn into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+///     where
+///         F: FnMut(Entity) -> Option<M>
+///     {
+///         let marker = ids(self.0).unwrap();
+///         Ok(TargetData(marker))
+///     }
+///
+///     fn from<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+///     where
+///         F: FnMut(M) -> Option<Entity>
+///     {
+///         let entity = ids(data.0).unwrap();
+///         Ok(Target(entity))
+///     }
+/// }
+///
+/// ```
+///
+pub trait ConvertSaveload<M>: Sized {
+    /// (De)Serializable data representation for data type
+    type Data: Serialize + DeserializeOwned;
+
+    /// Error may occur during serialization or deserialization of component
+    type Error;
+
+    /// Convert this data from a deserializable form (`Data`) using
+    /// entity to marker mapping function
+    fn from<F>(data: Self::Data, ids: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>;
+
+    /// Convert this data type into serializable form (`Data`) using
+    /// entity to marker mapping function
+    fn into<F>(&self, ids: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>;
+}
+
+impl<C, M> ConvertSaveload<M> for C
+where
+    C: Clone + Serialize + DeserializeOwned,
+{
+    type Data = Self;
+    type Error = NoError;
+
+    fn into<F>(&self, _: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        Ok(self.clone())
+    }
+
+    fn from<F>(data: Self::Data, _: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>,
+    {
+        Ok(data)
+    }
+}
+
+impl<M> ConvertSaveload<M> for Entity
+where
+    M: Serialize + DeserializeOwned,
+{
+    type Data = M;
+    type Error = NoError;
+
+    fn into<F>(&self, mut func: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        Ok(func(*self).unwrap())
+    }
+
+    fn from<F>(data: Self::Data, mut func: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>,
+    {
+        Ok(func(data).unwrap())
+    }
 }

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -9,7 +9,7 @@ use saveload::EntityData;
 use storage::{GenericReadStorage, ReadStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
-/// Converts a data type (usually a [`Component`]) into its serialized form.
+/// Converts a data type (usually a [`Component`]) into its serializable form.
 ///
 /// This is automatically implemented for any type that is
 /// [`Serialize`], yielding itself.
@@ -219,7 +219,7 @@ macro_rules! serialize_components {
             M: Marker,
             $(
                 $sto: GenericReadStorage<Component = $comp>,
-                $comp : IntoSerialize<M>+Component,
+                $comp : IntoSerialize<M> + Component,
                 E: From<<$comp as IntoSerialize<M>>::Error>,
             )*
         {

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -110,7 +110,7 @@ macro_rules! serialize_components {
             M: Marker,
             $(
                 $sto: GenericReadStorage<Component = $comp>,
-                $comp : ConvertSaveload<M> + Component,
+                $comp: ConvertSaveload<M> + Component,
                 E: From<<$comp as ConvertSaveload<M>>::Error>,
             )*
         {

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -4,25 +4,36 @@ use serde::ser::{self, Serialize, SerializeSeq, Serializer};
 
 use error::NoError;
 use join::Join;
-use saveload::EntityData;
 use saveload::marker::{Marker, MarkerAllocator};
+use saveload::EntityData;
 use storage::{GenericReadStorage, ReadStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
-/// Converts a component into its serialized form.
+/// Converts a data type (usually a [`Component`]) into its serialized form.
 ///
-/// This is automatically implemented for any type that is both
-/// a [`Component`] and [`Serialize`], yielding itself.
+/// This is automatically implemented for any type that is
+/// [`Serialize`], yielding itself.
 ///
 /// Implementing this yourself is usually only needed if you
-/// have a component that points to another Entity and you
-/// wish to [`Serialize`] it.
+/// have a component that points to another Entity, or has a field which does,
+///  and you wish to [`Serialize`] it.
 ///
 /// In most cases, you also likely want to implement the companion
 /// trait [`FromDeserialize`].
 ///
+/// *Note*: if you're using `specs_derive`
+/// and your struct does not have a generic bound (i.e. `struct Foo<T>`),
+/// you can use `#[derive(Saveload)]` to automatically derive this and
+/// [`FromDeserialize`]. You can get around generic type bounds by exploiting
+/// the newtype pattern (e.g. `struct FooU32(Foo<u32>);`).
+///
+/// You must add the `derive` to any type that your component holds which does
+/// not auto-implement these two traits, including the component itself (similar to how
+/// normal [`Serialize`] and [`Deserialize`] work).
+///
 /// [`Component`]: ../trait.Component.html
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
+/// [`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
 /// [`FromDeserialize`]: trait.FromDeserialize.html
 ///
 /// # Example
@@ -63,14 +74,14 @@ use world::{Component, EntitiesRes, Entity};
 ///
 /// ```
 ///
-pub trait IntoSerialize<M>: Component {
-    /// Serializable data representation for component
+pub trait IntoSerialize<M> {
+    /// Serializable data representation for data type
     type Data: Serialize;
 
     /// Error may occur during serialization or deserialization of component
     type Error;
 
-    /// Convert this component into serializable form (`Data`) using
+    /// Convert this data type into serializable form (`Data`) using
     /// entity to marker mapping function
     fn into<F>(&self, ids: F) -> Result<Self::Data, Self::Error>
     where
@@ -79,7 +90,7 @@ pub trait IntoSerialize<M>: Component {
 
 impl<C, M> IntoSerialize<M> for C
 where
-    C: Clone + Component + Serialize,
+    C: Clone + Serialize,
 {
     type Data = Self;
     type Error = NoError;
@@ -89,6 +100,21 @@ where
         F: FnMut(Entity) -> Option<M>,
     {
         Ok(self.clone())
+    }
+}
+
+impl<M> IntoSerialize<M> for Entity
+where
+    M: Serialize,
+{
+    type Data = M;
+    type Error = NoError;
+
+    fn into<F>(&self, mut func: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        Ok(func(*self).unwrap())
     }
 }
 
@@ -127,7 +153,8 @@ where
         for (entity, marker) in (&*entities, &*markers).join() {
             serseq.serialize_element(&EntityData::<M, Self::Data> {
                 marker: marker.clone(),
-                components: self.serialize_entity(entity, &ids)
+                components: self
+                    .serialize_entity(entity, &ids)
                     .map_err(ser::Error::custom)?,
             })?;
         }
@@ -173,7 +200,8 @@ where
                 for (entity, marker) in to_serialize {
                     serseq.serialize_element(&EntityData::<M, Self::Data> {
                         marker,
-                        components: self.serialize_entity(entity, &mut ids)
+                        components: self
+                            .serialize_entity(entity, &mut ids)
                             .map_err(ser::Error::custom)?,
                     })?;
                 }
@@ -191,7 +219,7 @@ macro_rules! serialize_components {
             M: Marker,
             $(
                 $sto: GenericReadStorage<Component = $comp>,
-                $comp : IntoSerialize<M>,
+                $comp : IntoSerialize<M>+Component,
                 E: From<<$comp as IntoSerialize<M>>::Error>,
             )*
         {

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -2,121 +2,12 @@ use std::fmt::Display;
 
 use serde::ser::{self, Serialize, SerializeSeq, Serializer};
 
-use error::NoError;
 use join::Join;
 use saveload::marker::{Marker, MarkerAllocator};
 use saveload::EntityData;
 use storage::{GenericReadStorage, ReadStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
-
-/// Converts a data type (usually a [`Component`]) into its serializable form.
-///
-/// This is automatically implemented for any type that is
-/// [`Serialize`], yielding itself.
-///
-/// Implementing this yourself is usually only needed if you
-/// have a component that points to another Entity, or has a field which does,
-///  and you wish to [`Serialize`] it.
-///
-/// In most cases, you also likely want to implement the companion
-/// trait [`FromDeserialize`].
-///
-/// *Note*: if you're using `specs_derive`
-/// and your struct does not have a generic bound (i.e. `struct Foo<T>`),
-/// you can use `#[derive(Saveload)]` to automatically derive this and
-/// [`FromDeserialize`]. You can get around generic type bounds by exploiting
-/// the newtype pattern (e.g. `struct FooU32(Foo<u32>);`).
-///
-/// You must add the `derive` to any type that your component holds which does
-/// not auto-implement these two traits, including the component itself (similar to how
-/// normal [`Serialize`] and [`Deserialize`] work).
-///
-/// [`Component`]: ../trait.Component.html
-/// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
-/// [`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
-/// [`FromDeserialize`]: trait.FromDeserialize.html
-///
-/// # Example
-///
-/// ```rust
-/// # extern crate specs;
-/// # #[macro_use] extern crate serde;
-/// use serde::Serialize;
-/// use specs::prelude::*;
-/// use specs::error::NoError;
-/// use specs::saveload::{Marker, IntoSerialize};
-///
-/// struct Target(Entity);
-///
-/// impl Component for Target {
-///     type Storage = VecStorage<Self>;
-/// }
-///
-/// // We need a matching "data" struct to hold our
-/// // marker. In general, you just need a single struct
-/// // per component you want to make `Serialize` with each
-/// // instance of `Entity` replaced with a generic "M".
-/// #[derive(Serialize)]
-/// struct TargetData<M>(M);
-///
-/// impl<M: Marker + Serialize> IntoSerialize<M> for Target {
-///     type Data = TargetData<M>;
-///     type Error = NoError;
-///
-///     fn into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
-///     where
-///         F: FnMut(Entity) -> Option<M>
-///     {
-///         let marker = ids(self.0).unwrap();
-///         Ok(TargetData(marker))
-///     }
-/// }
-///
-/// ```
-///
-pub trait IntoSerialize<M> {
-    /// Serializable data representation for data type
-    type Data: Serialize;
-
-    /// Error may occur during serialization or deserialization of component
-    type Error;
-
-    /// Convert this data type into serializable form (`Data`) using
-    /// entity to marker mapping function
-    fn into<F>(&self, ids: F) -> Result<Self::Data, Self::Error>
-    where
-        F: FnMut(Entity) -> Option<M>;
-}
-
-impl<C, M> IntoSerialize<M> for C
-where
-    C: Clone + Serialize,
-{
-    type Data = Self;
-    type Error = NoError;
-
-    fn into<F>(&self, _: F) -> Result<Self::Data, Self::Error>
-    where
-        F: FnMut(Entity) -> Option<M>,
-    {
-        Ok(self.clone())
-    }
-}
-
-impl<M> IntoSerialize<M> for Entity
-where
-    M: Serialize,
-{
-    type Data = M;
-    type Error = NoError;
-
-    fn into<F>(&self, mut func: F) -> Result<Self::Data, Self::Error>
-    where
-        F: FnMut(Entity) -> Option<M>,
-    {
-        Ok(func(*self).unwrap())
-    }
-}
+use super::ConvertSaveload;
 
 /// A trait which allows to serialize entities and their components.
 pub trait SerializeComponents<E, M>
@@ -219,8 +110,8 @@ macro_rules! serialize_components {
             M: Marker,
             $(
                 $sto: GenericReadStorage<Component = $comp>,
-                $comp : IntoSerialize<M> + Component,
-                E: From<<$comp as IntoSerialize<M>>::Error>,
+                $comp : ConvertSaveload<M> + Component,
+                E: From<<$comp as ConvertSaveload<M>>::Error>,
             )*
         {
             type Data = ($(Option<$comp::Data>,)*);


### PR DESCRIPTION
Split from #434
A custom derive for IntoSerialize and FromDeserialize named #[derive(Saveload)]. It may seem odd to derive them together, but after spending significant time trying to do it the normal way (one derive per trait) it became clear that due to the requirement of "proxy" types that fill the IntoSerialize::Data and FromDeserialize::Data fields, it made sense to do it this way or you start getting into attribute hell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/460)
<!-- Reviewable:end -->
