### PR TITLE
Saveload convenience macro

### DIFF
--- a/src/saveload/de.rs
+++ b/src/saveload/de.rs
@@ -11,6 +11,12 @@ use storage::{GenericWriteStorage, WriteStorage};
 use world::{Component, EntitiesRes, Entity};
 
 /// A trait which allows to deserialize entities and their components.
+///
+/// Instead of implementing this trait and its companion [`SerializeComponents`] directly,
+/// you may wish to use the [`saveload_components`] macro.
+///
+/// [`SerializeComponents`]: ./SerializeComponents.t.html
+/// [`saveload_components`]: ../macro.saveload_components.html
 pub trait DeserializeComponents<E, M>
 where
     Self: Sized,

--- a/src/saveload/macros.rs
+++ b/src/saveload/macros.rs
@@ -1,0 +1,211 @@
+/// This macro is a convenience wrapper for the most common method of serializing or deserializing components.
+///
+/// This takes several arguments: a list of components surrounded by brackets `[ Foo, Bar, Baz ]`,
+/// the target name of the generated deserialization system data, the
+/// target name of the serialization system data, the target name of the intermediate data struct all your
+/// components will be serialized from (essentially a big list of [`<T as IntoSerialize>::Data`]),
+/// and finally, the absolute path of the module this is invoked from (`::` for root), the latter is a workaround
+/// for some privacy issues.
+///
+/// At the site of invocation, it will create a submodule named `saveload_generated` containing the struct names
+/// given in the arguments.
+///
+/// The deserialization derives [`SystemData`] and contains:
+///
+/// - An opaque field containing the [`WriteStorage`]s to the given components, implementing [`DeserializeComponents`] (named `components`)
+/// - A [`WriteStorage`] handle to a generic [`Marker`] (named `markers`)
+/// - A [`Write`] handle to a [`MarkerAllocator`] parameterized by said [`Marker`] (named `alloc`)
+/// - The [`Entities`] resource (named `entities`)
+///
+/// The serialization struct also derives [`SystemData`] and contains:
+///
+/// - An opaque field containing the [`ReadStorage`]s to the given components, implementing [`SerializeComponents`] (named `components`)
+/// - A [`ReadStorage`] handle to a generic [`Marker`] (named `markers)
+/// - The [`Entities`] resource (named `entities`)
+///
+/// This is set up so that by making the generated a field in the [`SystemData`] for your [`System`], you automatically have every
+/// element necessary to immediately call [`DeserializeComponents::deserialize`] or [`SerializeComponents::serialize`].
+///
+///
+/// Note that this will still play nicely with non-trivial systems, provided you don't ask for any systems you give to this macro
+/// again. You can still fetch certain [`Component`]s mutably in your [`SystemData`], for instance, if you wish to derive their values instead of directly
+/// serializing them. For example:
+///
+/// ```rust
+/// # #[macro_use]
+/// # extern crate specs;
+/// # #[macro_use]
+/// # extern crate specs_derive;
+/// # #[macro_use]
+/// # extern crate serde;
+/// # #[macro_use]
+/// # extern crate shred_derive;
+/// # extern crate shred;
+/// #
+/// # use specs::prelude::*;
+/// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
+/// # #[storage(VecStorage)]
+/// # struct Foo;
+/// #
+/// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
+/// # #[storage(VecStorage)]
+/// # struct Bar;
+/// #
+/// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
+/// # #[storage(VecStorage)]
+/// # struct Baz;
+/// #
+/// saveload_components!{[Foo, Bar], Deser, Ser, Data, ::}
+///
+/// use specs::saveload::{U64MarkerAllocator, U64Marker};
+///
+/// #[derive(SystemData)]
+/// struct NonTrivial<'a> {
+///     // We could derive this from any entity with both `Foo` and `Bar` for example
+///     baz: WriteStorage<'a, Baz>,
+///     de: saveload_generated::Deser<'a, U64Marker, U64MarkerAllocator>,
+/// }
+/// # // This shadow main has to be here or we get a "macro_use must be declared in the crate root"
+/// # // error
+/// # fn main() {
+/// # }
+/// ```
+///
+/// Will allow us to do things with `Baz` while still giving us a common place to define the components we want
+/// to serialize and deserialize (reducing errors because we added one to one collection but not the other).
+///
+///
+///
+/// [`<T as IntoSerialize>::Data`]: ./saveload/IntoSerialize.t.html#associatedtype.Data
+/// [`DeserializeComponents`]: ./saveload/DeserializeComponents.t.html
+/// [`SerializeComponents`]: ./saveload/SerializeComponents.t.html
+/// [`DeserializeComponents::deserialize`]: ./saveload/DeserializeComponents.t.html#method.deserialize
+/// [`SerializeComponents::serialize`]: ./saveload/SerializeComponents.t.html#method.serialize
+/// [`Marker`]: ./saveload/Marker.t.html
+/// [`MarkerAllocator`]: ./saveload/MarkerAllocator.t.html
+/// [`WriteStorage`]: WriteStorage.t.html
+/// [`Write`]: Write.t.html
+/// [`Component`]: Component.t.html
+/// [`ReadStorage`]: ReadStorage.t.html
+/// [`Entities`]: Entities.t.html
+/// [`SystemData`]: SystemData.t.html
+#[macro_export]
+macro_rules! saveload_components {
+    ( [ $($name:ident),* ],  $deser_name:ident, $ser_name:ident, $data_name:ident, $abs_mod:tt) => {
+        mod saveload_generated {
+            #![allow(unused_imports)]
+            
+            use super::*;
+            use $crate::saveload::*;
+            use $crate::prelude::*;
+            use ::serde::{Serialize, Deserialize};
+
+            /// The serialized version of these components
+            #[allow(non_snake_case)]
+            #[derive(Serialize, Deserialize)]
+            #[serde(bound="")]
+            pub(super) struct $data_name<MA>
+            where
+                MA: Marker+::serde::Serialize,
+                for<'deser> MA: ::serde::Deserialize<'deser>,
+            {
+                $(pub(super) $name: Option<<$name as IntoSerialize<MA>>::Data> ),*
+            }
+
+            /// The generated deserializer system data
+            #[derive(SystemData)]
+            #[allow(dead_code)]
+            pub(super) struct $deser_name<'a, M: Marker, A: MarkerAllocator<M> > {
+                pub(super) markers: WriteStorage<'a, M>,
+                pub(super) entities: Entities<'a>,
+                pub(super) alloc: Write<'a, A>,
+                pub(super) components: self::deser_components::$deser_name<'a>,
+            }
+
+            pub(super) use self::deser_components::$deser_name as DeserComponents;
+
+            mod deser_components {
+                #![allow(unused_imports)]
+
+                use $crate::WriteStorage;
+                use $crate::saveload::Marker;
+                use super::*;
+
+                #[allow(non_snake_case)]
+                #[derive(SystemData)]
+                pub(crate) struct $deser_name<'a> {
+                    $( pub(super) $name: WriteStorage<'a, $name> ),*
+                }
+            }
+
+            impl<'a, M> DeserializeComponents<$crate::error::NoError, M> for self::deser_components::$deser_name<'a>
+            where 
+                M: Marker+'a,
+            {
+                type Data = $data_name<M>;
+
+                fn deserialize_entity<F>(
+                    &mut self,
+                    entity: Entity,
+                    components: Self::Data,
+                    mut ids: F,
+                ) -> Result<(), $crate::error::NoError>
+                where
+                    F: FnMut(M) -> Option<Entity> 
+                {
+                    $(if let Some(comp) = components.$name {
+                        let comp: $name = FromDeserialize::from(comp, &mut ids)?;
+                        self.$name.insert(entity, comp).unwrap();
+                    });*
+
+                    Ok(())
+                }
+            }
+
+            /// The generated deserializer system data
+            #[derive(SystemData)]
+            #[allow(dead_code)]
+            pub(super) struct $ser_name<'a, M: Marker> {
+                pub(super) markers: ReadStorage<'a, M>,
+                pub(super) entities: Entities<'a>,
+                pub(super) components: self::ser_components::$ser_name<'a>,
+            }
+
+            pub(super) use self::ser_components::$ser_name as SerComponents;
+
+            mod ser_components {
+                #![allow(unused_imports)]
+
+                use $crate::ReadStorage;
+                use $crate::saveload::Marker;
+                use super::*;
+
+                #[allow(non_snake_case)]
+                #[derive(SystemData)]
+                pub(crate) struct $ser_name<'a> {
+                    $( pub(super) $name: ReadStorage<'a, $name> ),*
+                }
+            }
+
+            impl<'a, M> SerializeComponents<$crate::error::NoError, M> for self::ser_components::$ser_name<'a>
+            where 
+                M: Marker, 
+            {
+                type Data = $data_name<M>;
+
+                fn serialize_entity<F>(&self, entity: Entity, mut ids: F) -> Result<Self::Data, $crate::error::NoError>
+                where
+                    F: FnMut(Entity) -> Option<M>
+                {
+                    Ok($data_name {
+                        $($name: if let Some(comp) = self.$name.get(entity) {
+                            Some(IntoSerialize::into(comp, &mut ids).unwrap())
+                        } else { 
+                            None 
+                        }),*   
+                    })
+                }
+            }
+        }
+    }
+}

--- a/src/saveload/macros.rs
+++ b/src/saveload/macros.rs
@@ -43,15 +43,15 @@
 /// # use specs::prelude::*;
 /// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
 /// # #[storage(VecStorage)]
-/// # struct Foo;
+/// # pub struct Foo;
 /// #
 /// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
 /// # #[storage(VecStorage)]
-/// # struct Bar;
+/// # pub struct Bar;
 /// #
 /// # #[derive(Copy, Clone, Debug, Serialize, Deserialize, Component)]
 /// # #[storage(VecStorage)]
-/// # struct Baz;
+/// # pub struct Baz;
 /// #
 /// saveload_components!{[Foo, Bar], Deser, Ser, Data}
 ///
@@ -102,27 +102,30 @@ macro_rules! saveload_components {
             #[allow(non_snake_case)]
             #[derive(Serialize, Deserialize)]
             #[serde(bound="")]
-            pub(crate) struct $data_name<MA>
+            #[doc(hidden)]
+            pub struct $data_name<MA>
             where
                 MA: Marker+::serde::Serialize,
                 for<'deser> MA: ::serde::Deserialize<'deser>,
             {
-                $(pub(crate) $name: Option<<$name as IntoSerialize<MA>>::Data> ),*
+                $(pub $name: Option<<$name as IntoSerialize<MA>>::Data> ),*
             }
 
             /// The generated deserializer system data
             #[derive(SystemData)]
             #[allow(dead_code)]
-            pub(crate) struct $deser_name<'a, M: Marker, A: MarkerAllocator<M> > {
-                pub(crate) markers: WriteStorage<'a, M>,
-                pub(crate) entities: Entities<'a>,
-                pub(crate) alloc: Write<'a, A>,
-                pub(crate) components: self::deser_components::$deser_name<'a>,
+            #[doc(hidden)]
+            pub struct $deser_name<'a, M: Marker, A: MarkerAllocator<M> > {
+                pub markers: WriteStorage<'a, M>,
+                pub entities: Entities<'a>,
+                pub alloc: Write<'a, A>,
+                pub components: self::deser_components::$deser_name<'a>,
             }
 
-            pub(crate) use self::deser_components::$deser_name as DeserComponents;
+            pub use self::deser_components::$deser_name as DeserComponents;
 
-            mod deser_components {
+            #[doc(hidden)]
+            pub mod deser_components {
                 #![allow(unused_imports)]
 
                 use $crate::WriteStorage;
@@ -131,8 +134,9 @@ macro_rules! saveload_components {
 
                 #[allow(non_snake_case)]
                 #[derive(SystemData)]
-                pub(crate) struct $deser_name<'a> {
-                    $( pub(crate) $name: WriteStorage<'a, $name> ),*
+                #[doc(hidden)]
+                pub struct $deser_name<'a> {
+                    $( pub $name: WriteStorage<'a, $name> ),*
                 }
             }
 
@@ -163,15 +167,17 @@ macro_rules! saveload_components {
             /// The generated deserializer system data
             #[derive(SystemData)]
             #[allow(dead_code)]
-            pub(crate) struct $ser_name<'a, M: Marker> {
-                pub(crate) markers: ReadStorage<'a, M>,
-                pub(crate) entities: Entities<'a>,
-                pub(crate) components: self::ser_components::$ser_name<'a>,
+            #[doc(hidden)]
+            pub struct $ser_name<'a, M: Marker> {
+                pub markers: ReadStorage<'a, M>,
+                pub entities: Entities<'a>,
+                pub components: self::ser_components::$ser_name<'a>,
             }
 
-            pub(crate) use self::ser_components::$ser_name as SerComponents;
+            pub use self::ser_components::$ser_name as SerComponents;
 
-            mod ser_components {
+            #[doc(hidden)]
+            pub mod ser_components {
                 #![allow(unused_imports)]
 
                 use $crate::ReadStorage;
@@ -180,8 +186,9 @@ macro_rules! saveload_components {
 
                 #[allow(non_snake_case)]
                 #[derive(SystemData)]
-                pub(crate) struct $ser_name<'a> {
-                    $( pub(crate) $name: ReadStorage<'a, $name> ),*
+                #[doc(hidden)]
+                pub struct $ser_name<'a> {
+                    $( pub $name: ReadStorage<'a, $name> ),*
                 }
             }
 

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -23,6 +23,8 @@
 //! see the docs for the `Marker` trait.
 //!
 
+mod macros;
+
 mod de;
 mod marker;
 mod ser;

--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -93,6 +93,12 @@ where
 }
 
 /// A trait which allows to serialize entities and their components.
+///
+/// Instead of implementing this trait and its companion [`DeserializeComponents`] directly,
+/// you may wish to use the [`saveload_components`] macro.
+///
+/// [`DeserializeComponents`]: ./DeserializeComponents.t.html
+/// [`saveload_components`]: ../macro.saveload_components.html
 pub trait SerializeComponents<E, M>
 where
     M: Marker,

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -99,6 +99,8 @@ impl<'a> System<'a> for SerSys {
 
 #[test]
 fn saveload_macro() {
+    use specs::saveload::MarkedBuilder;
+
     let mut world = setup_world();
     let entity = world
         .create_entity()

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "serde")]
+
+#[macro_use]
+extern crate specs;
+#[macro_use]
+extern crate specs_derive;
+#[macro_use]
+extern crate shred_derive;
+#[macro_use]
+extern crate serde;
+extern crate ron;
+extern crate serde_json;
+extern crate shred;
+
+use specs::prelude::*;
+use specs::saveload::{U64Marker, U64MarkerAllocator};
+
+#[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
+#[storage(VecStorage)]
+struct Pos {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
+#[storage(VecStorage)]
+struct Vel {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Copy, Clone, Component, Saveload)]
+#[storage(VecStorage)]
+struct OwnsEntity(Entity);
+
+saveload_components!{
+    [Pos, Vel, OwnsEntity], DeData, SerData, Data, crate
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Default, Debug)]
+struct Serialized {
+    json: String,
+}
+
+#[derive(SystemData)]
+struct DeSysData<'a> {
+    de: saveload_generated::DeData<'a, U64Marker, U64MarkerAllocator>,
+    target: Read<'a, Serialized>,
+}
+
+struct DeSys;
+
+impl<'a> System<'a> for DeSys {
+    type SystemData = DeSysData<'a>;
+
+    fn run(&mut self, mut sys_data: Self::SystemData) {
+        use ron::de::Deserializer;
+        use specs::error::NoError;
+        use specs::saveload::DeserializeComponents;
+
+        if let Ok(mut de) = Deserializer::from_str(&sys_data.target.json) {
+            DeserializeComponents::<NoError, U64Marker>::deserialize(
+                &mut sys_data.de.components,
+                &sys_data.de.entities,
+                &mut sys_data.de.markers,
+                &mut sys_data.de.alloc,
+                &mut de,
+            ).unwrap();
+        }
+    }
+}
+
+struct SerSys;
+
+#[derive(SystemData)]
+struct SerSysData<'a> {
+    ser: saveload_generated::SerData<'a, U64Marker>,
+    target: Write<'a, Serialized>,
+}
+
+impl<'a> System<'a> for SerSys {
+    type SystemData = SerSysData<'a>;
+
+    fn run(&mut self, mut sys_data: Self::SystemData) {
+        use specs::error::NoError;
+        use specs::saveload::SerializeComponents;
+
+        let mut ser = ron::ser::Serializer::new(Some(Default::default()), true);
+        SerializeComponents::<NoError, U64Marker>::serialize(
+            &sys_data.ser.components,
+            &sys_data.ser.entities,
+            &sys_data.ser.markers,
+            &mut ser,
+        ).unwrap();
+
+        sys_data.target.json = ser.into_output_string();
+    }
+}
+
+#[test]
+fn saveload_macro() {
+    let mut world = setup_world();
+    let entity = world
+        .create_entity()
+        .with(Pos { x: 5.2, y: 9.1 })
+        .with(Vel { x: 0.0, y: 1.0 })
+        .marked::<U64Marker>()
+        .build();
+
+    let mut ser = SerSys;
+
+    ser.run_now(&world.res);
+
+    let mut world2 = setup_world();
+    world2.add_resource(world.read_resource::<Serialized>().clone());
+    let mut de = DeSys;
+
+    de.run_now(&world2.res);
+    world2.maintain();
+
+    let mut len = 0;
+
+    for (pos, vel) in (&world2.read_storage::<Pos>(), &world2.read_storage::<Vel>()).join() {
+        len += 1;
+        assert!(len < 2);
+
+        assert_eq!(*pos, *world.read_storage().get(entity).unwrap());
+        assert_eq!(*vel, *world.read_storage().get(entity).unwrap());
+    }
+}
+
+fn setup_world() -> World {
+    let mut world = World::new();
+
+    world.maintain();
+    world.add_resource(Serialized::default());
+    world.add_resource(U64MarkerAllocator::new());
+
+    world.register::<Pos>();
+    world.register::<Vel>();
+    world.register::<OwnsEntity>();
+    world.register::<U64Marker>();
+
+    world
+}

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -17,21 +17,21 @@ use specs::saveload::{U64Marker, U64MarkerAllocator};
 
 #[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
 #[storage(VecStorage)]
-struct Pos {
+pub struct Pos {
     x: f64,
     y: f64,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, Component, Debug, PartialEq)]
 #[storage(VecStorage)]
-struct Vel {
+pub struct Vel {
     x: f64,
     y: f64,
 }
 
 #[derive(Copy, Clone, Component, Saveload)]
 #[storage(VecStorage)]
-struct OwnsEntity(Entity);
+pub struct OwnsEntity(Entity);
 
 saveload_components!{
     [Pos, Vel, OwnsEntity], DeData, SerData, Data

--- a/tests/saveload_macro.rs
+++ b/tests/saveload_macro.rs
@@ -34,7 +34,7 @@ struct Vel {
 struct OwnsEntity(Entity);
 
 saveload_components!{
-    [Pos, Vel, OwnsEntity], DeData, SerData, Data, crate
+    [Pos, Vel, OwnsEntity], DeData, SerData, Data
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Default, Debug)]


### PR DESCRIPTION
Split from #434 
A macro which automatically will create SystemData for the most common usecase of SerializeComponents and DeserializeComponents. Unlike the existing tuple auto-implementation, this generates arbitrarily large structs that you can readily plop straight into your serialization or deserialization system. It also doesn't use recursion, so it shouldn't hit any nasty macro expansion recursion limits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/461)
<!-- Reviewable:end -->
