### PR TITLE
Book dispatcher chapter - print updated positions

### DIFF
--- a/book/src/03_dispatcher.md
+++ b/book/src/03_dispatcher.md
@@ -80,14 +80,14 @@ same for every entity). The solution to this are `Resource`s, see
 
 ## Adding a system with a dependency
 
-Okay, now you can add another system *after* the `HelloWorld` system:
+Okay, we'll add two more systems *after* the `HelloWorld` system:
 
 ```rust,ignore
     .with(UpdatePos, "update_pos", &["hello_world"])
+    .with(HelloWorld, "hello_updated", &["update_pos"])
 ```
-
 The `UpdatePos` system now depends on the `HelloWorld` system and will only
-be executed after the dependency has finished.
+be executed after the dependency has finished. The final `HelloWorld` system prints the resulting updated positions.
 
 Now to execute all the systems, just do
 
@@ -169,6 +169,7 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .with(HelloWorld, "hello_world", &[])
         .with(UpdatePos, "update_pos", &["hello_world"])
+        .with(HelloWorld, "hello_updated", &["update_pos"])
         .build();
 
     dispatcher.dispatch(&mut world.res);


### PR DESCRIPTION
Small change to the dispatcher chapter of the book as discussed in #408. If you run the example code now you'll see the final printed positions include the changes made by `UpdatePos`. This should make it a little easier for someone following along with the examples to verify that their code is working correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/464)
<!-- Reviewable:end -->
