### PR TITLE
Remove coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **S**pecs **P**arallel **ECS**
 
-[![Build Status][bi]][bl] [![Crates.io][ci]][cl] [![Gitter][gi]][gl] ![MIT/Apache][li] [![Docs.rs][di]][dl] [![Coverage][cci]][ccl] ![LoC][lo]
+[![Build Status][bi]][bl] [![Crates.io][ci]][cl] [![Gitter][gi]][gl] ![MIT/Apache][li] [![Docs.rs][di]][dl] ![LoC][lo]
 
 [bi]: https://travis-ci.org/slide-rs/specs.svg?branch=master
 [bl]: https://travis-ci.org/slide-rs/specs
@@ -17,9 +17,6 @@
 
 [gi]: https://badges.gitter.im/slide-rs/specs.svg
 [gl]: https://gitter.im/slide-rs/specs
-
-[cci]: https://coveralls.io/repos/github/slide-rs/specs/badge.svg?branch=master
-[ccl]: https://coveralls.io/github/slide-rs/specs?branch=master
 
 [lo]: https://tokei.rs/b1/github/slide-rs/specs?category=code
 


### PR DESCRIPTION
Badge wasn't updated and coverage report was inconsistent; we sometimes got lower coverage because I added a comment, that's why I needed to disable the integration.

Fixes #430

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/465)
<!-- Reviewable:end -->
