### PR TITLE
Switched specs-derive to use Component in scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ criterion = "0.2"
 ron = "0.4"
 rand = "0.5.5"
 serde_json = "1.0"
-specs-derive = { path = "specs-derive", version = "0.2.0" }
+specs-derive = { path = "specs-derive", version = "0.3.0" }
 
 [[example]]
 name = "async"

--- a/specs-derive/Cargo.toml
+++ b/specs-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs-derive"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Custom derive macro for Specs components"
 documentation = "https://docs.rs/specs-derive"

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -58,7 +58,7 @@ fn impl_component(ast: &DeriveInput) -> Tokens {
         .unwrap_or_else(|| parse_quote!(DenseVecStorage));
 
     quote! {
-        impl #impl_generics ::specs::world::Component for #name #ty_generics #where_clause {
+        impl #impl_generics Component for #name #ty_generics #where_clause {
             type Storage = #storage<Self>;
         }
     }


### PR DESCRIPTION
"Works on my pc".

So with this you need to have `Component` in scope for the derive to find it and use it. This allows to use it in projects without having to have specs as a hard dependency. <3

Also it might fix the issue with re-exporting the macro, but I didn't test that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/467)
<!-- Reviewable:end -->
