### PR TITLE
resolve method not defined error

### DIFF
--- a/book/src/02_hello_world.md
+++ b/book/src/02_hello_world.md
@@ -80,7 +80,7 @@ need to create a world in which to store all of our components.
 ## The `World`
 
 ```rust,ignore
-use specs::World;
+use specs::{World, Builder};
 
 let mut world = World::new();
 world.register::<Position>();


### PR DESCRIPTION
With this code so far, following along:
```
extern crate specs;
#[macro_use]
extern crate specs_derive;

use specs::{VecStorage, World};


#[derive(Component, Debug)]
#[storage(VecStorage)]
struct Position {
    x: f32,
    y: f32
}

#[derive(Component, Debug)]
#[storage(VecStorage)]
struct Velocity {
    x: f32,
    y: f32,
}

fn main() {
    let mut world = World::new();
    world.register::<Position>();

    let ball = world.create_entity().with(Position { x: 4.0, y: 7.0 }).build();
}
```
one gets this error:
```
error[E0599]: no method named `with` found for type `specs::EntityBuilder<'_>` in the current scope
  --> src/main.rs:26:38
   |
26 |     let ball = world.create_entity().with(Position { x: 4.0, y: 7.0 }).build();
   |                                      ^^^^
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope, perhaps add a `use` for it:
   |
5  | use specs::Builder;
   |
```
This change just does what's suggested and we can compile fine.

I like to compile often, letting `rustc` check for typos and other errors.  I'm sure other beginners do also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/469)
<!-- Reviewable:end -->
