### PR TITLE
Deprecate world::Bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 * Implement `Join` on `Fetch`/`Read`/`Write`/etc. to eliminate unnecessary dereference ([#472])
 * Generation now internally uses the new `NonZeroI32` from `nonzero_signed`, meaning `Option<Entity>` is the same size as `Entity`.
 Note this bumps the minimum supported rust version to 1.28.0 ([#447]).
+* Deprecated `world::Bundle` ([#486])
 
 [#447]: https://github.com/slide-rs/specs/pull/447
 [#472]: https://github.com/slide-rs/specs/pull/472
+[#486]: https://github.com/slide-rs/specs/pull/486
 
 # 0.12.3
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -575,6 +575,7 @@ impl World {
     }
 
     /// Adds the given bundle of resources/components.
+    #[deprecated(note="Please read the book's chapter on setup: https://slide-rs.github.io/specs/07_setup.html")]
     pub fn add_bundle<B>(&mut self, bundle: B)
     where
         B: Bundle,
@@ -613,6 +614,7 @@ impl Default for World {
 }
 
 /// Trait used to bundle up resources/components for easy registration with `World`.
+#[deprecated(note="Please read the book's chapter on setup: https://slide-rs.github.io/specs/07_setup.html")]
 pub trait Bundle {
     /// Add resources/components to `world`.
     fn add_to_world(self, world: &mut World);


### PR DESCRIPTION
Hello,

`world::World::exec` can be used instead of implementing `world::Bundle`

Related issue: #482 

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/486)
<!-- Reviewable:end -->
