### PR TITLE
FlaggedStorage changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ Note this bumps the minimum supported rust version to 1.28.0 ([#447]).
 * Deprecated `world::Bundle` ([#486])
 * Updated Chapter 7: Setup to be more explicit, updated examples to follow that methodology ([#487])
 * Updated dependency versions ([#494])
+* FlaggedStorage rewrite with single event channel instead of multiple for odering. ([#489])
 
 [#447]: https://github.com/slide-rs/specs/pull/447
 [#486]: https://github.com/slide-rs/specs/pull/486
 [#487]: https://github.com/slide-rs/specs/pull/487
+[#489]: https://github.com/slide-rs/specs/pull/489
 [#494]: https://github.com/slide-rs/specs/pull/494
 
 # 0.12.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ name = "bitset"
 name = "track"
 
 [[example]]
+name = "ordered_track"
+
+[[example]]
 name = "common"
 required-features = ["common"]
 

--- a/examples/ordered_track.rs
+++ b/examples/ordered_track.rs
@@ -1,0 +1,107 @@
+extern crate hibitset;
+extern crate shrev;
+extern crate specs;
+
+use std::collections::HashMap;
+
+use specs::prelude::*;
+
+struct TrackedComponent(u64);
+
+impl Component for TrackedComponent {
+    type Storage = FlaggedStorage<Self>;
+}
+
+#[derive(Default)]
+struct SysA {
+    reader_id: Option<ReaderId<ComponentEvent>>,
+    cache: HashMap<u32, (Entity, u64)>,
+}
+
+impl<'a> System<'a> for SysA {
+    type SystemData = (Entities<'a>, ReadStorage<'a, TrackedComponent>);
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        self.reader_id = Some(WriteStorage::<TrackedComponent>::fetch(&res).track());
+    }
+
+    fn run(&mut self, (entities, tracked): Self::SystemData) {
+        let events = tracked
+            .channel()
+            .read(self.reader_id.as_mut().expect("ReaderId not found"));
+        for event in events {
+            match event {
+                ComponentEvent::Modified(id) => {
+                    let entity = entities.entity(*id);
+                    if let Some(component) = tracked.get(entity) {
+                        *self.cache.get_mut(id).unwrap() = (entity, component.0);
+                        println!("{:?} was changed to {:?}", entity, component.0);
+                    } else {
+                        println!(
+                            "{:?} was changed, but was removed before the next update.",
+                            entity
+                        );
+                    }
+                }
+                ComponentEvent::Inserted(id) => {
+                    let entity = entities.entity(*id);
+                    if let Some(component) = tracked.get(entity) {
+                        self.cache.insert(*id, (entity, component.0));
+                        println!("{:?} had {:?} inserted", entity, component.0);
+                    } else {
+                        println!("{:?} had a component inserted, but was removed before the next update.", entity);
+                    }
+                }
+                ComponentEvent::Removed(id) => {
+                    let entity = entities.entity(*id);
+                    self.cache.remove(id);
+                    println!("{:?} had its component removed", entity);
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let mut world = World::new();
+
+    let mut dispatcher = DispatcherBuilder::new()
+        .with(SysA::default(), "sys_a", &[])
+        .build();
+
+    dispatcher.setup(&mut world.res);
+
+    let e1 = world.create_entity().with(TrackedComponent(1)).build();
+    let e2 = world.create_entity().with(TrackedComponent(2)).build();
+    let e3 = world.create_entity().with(TrackedComponent(3)).build();
+    let e4 = world.create_entity().with(TrackedComponent(4)).build();
+
+    dispatcher.dispatch(&mut world.res);
+    world.maintain();
+
+    {
+        let mut tracked = world.write_storage::<TrackedComponent>();
+        tracked.get_mut(e1).unwrap().0 = 0;
+        tracked.get_mut(e2).unwrap().0 = 50;
+        tracked.get_mut(e4).unwrap().0 *= 2;
+        tracked.remove(e1);
+    }
+
+    dispatcher.dispatch(&mut world.res);
+    world.maintain();
+
+    {
+        let mut tracked = world.write_storage::<TrackedComponent>();
+
+        // Note that any removal after a modification won't be seen in the next frame, instead you
+        // will find no component or if a new component was inserted right after it was inserted then
+        // then you will find the new inserted component rather than the modified one from earlier.
+        tracked.get_mut(e3).unwrap().0 = 20;
+        tracked.remove(e3);
+        tracked.insert(e3, TrackedComponent(10));
+    }
+
+    dispatcher.dispatch(&mut world.res);
+    world.maintain();
+}

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -23,7 +23,7 @@ impl<'a> System<'a> for SysA {
 
     fn setup(&mut self, res: &mut Resources) {
         Self::SystemData::setup(res);
-        self.reader_id = Some(WriteStorage::<TrackedComponent>::fetch(&res).track());
+        self.reader_id = Some(WriteStorage::<TrackedComponent>::fetch(&res).register_reader());
     }
 
     fn run(&mut self, (entities, tracked): Self::SystemData) {

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -13,6 +13,7 @@ impl Component for TrackedComponent {
 #[derive(Default)]
 struct SysA {
     reader_id: Option<ReaderId<ComponentEvent>>,
+    events: Vec<ComponentEvent>,
     inserted: BitSet,
     modified: BitSet,
     removed: BitSet,
@@ -27,15 +28,36 @@ impl<'a> System<'a> for SysA {
     }
 
     fn run(&mut self, (entities, tracked): Self::SystemData) {
+        self.events  = tracked.channel().read(self.reader_id.as_mut().expect("ReaderId not found")).map(|e| *e).collect();
+
         self.modified.clear();
-        let events = tracked.channel().read(self.reader_id.as_mut().expect("ReaderId not found"));
-        self.modified.extend(events.filter_map(|event| match event {
+        self.modified.extend(self.events.iter().filter_map(|event| match event {
             ComponentEvent::Modified(index) => Some(index),
+            _ => None,
+        }));
+
+        self.inserted.clear();
+        self.inserted.extend(self.events.iter().filter_map(|event| match event {
+            ComponentEvent::Inserted(index) => Some(index),
+            _ => None,
+        }));
+
+        self.removed.clear();
+        self.removed.extend(self.events.iter().filter_map(|event| match event {
+            ComponentEvent::Removed(index) => Some(index),
             _ => None,
         }));
 
         for (entity, _tracked, _) in (&entities, &tracked, &self.modified).join() {
             println!("modified: {:?}", entity);
+        }
+
+        for (entity, _tracked, _) in (&entities, &tracked, &self.inserted).join() {
+            println!("inserted: {:?}", entity);
+        }
+            
+        for (entity, _tracked, _) in (&entities, &tracked, &self.removed).join() {
+            println!("removed: {:?}", entity);
         }
     }
 }
@@ -64,12 +86,19 @@ fn main() {
 
     dispatcher.setup(&mut world.res);
 
-    for _ in 0..10000 {
+    for _ in 0..50 {
         world.create_entity().with(TrackedComponent(0)).build();
     }
 
     dispatcher.dispatch(&mut world.res);
     world.maintain();
+
+    let entities = (&world.entities(), &world.read_storage::<TrackedComponent>()).join().map(|(e, _)| e).collect::<Vec<Entity>>();
+    world.delete_entities(&entities);
+
+    for _ in 0..50 {
+        world.create_entity().with(TrackedComponent(0)).build();
+    }
 
     dispatcher.dispatch(&mut world.res);
     world.maintain();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,6 @@ pub use shrev::ReaderId;
 pub use shred::AsyncDispatcher;
 
 pub use changeset::ChangeSet;
-pub use storage::{DenseVecStorage, FlaggedStorage, HashMapStorage, InsertedFlag, ModifiedFlag,
-                  NullStorage, ReadStorage, RemovedFlag, Storage, Tracked, VecStorage,
+pub use storage::{DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage, ReadStorage, Storage, Tracked, VecStorage,
                   WriteStorage};
 pub use world::{Builder, Component, Entities, Entity, EntityBuilder, LazyUpdate, World};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,10 @@
 
 pub use hibitset::BitSet;
 pub use join::{Join, ParJoin};
-pub use shred::{Accessor, Dispatcher, DispatcherBuilder, Read, ReadExpect, Resources, RunNow,
-                StaticAccessor, System, SystemData, Write, WriteExpect};
+pub use shred::{
+    Accessor, Dispatcher, DispatcherBuilder, Read, ReadExpect, Resources, RunNow, StaticAccessor,
+    System, SystemData, Write, WriteExpect,
+};
 pub use shrev::ReaderId;
 
 #[cfg(not(target_os = "emscripten"))]
@@ -14,7 +16,8 @@ pub use rayon::iter::ParallelIterator;
 pub use shred::AsyncDispatcher;
 
 pub use changeset::ChangeSet;
-pub use storage::{DenseVecStorage, FlaggedStorage, HashMapStorage, InsertedFlag, ModifiedFlag,
-                  NullStorage, ReadStorage, RemovedFlag, Storage, Tracked, VecStorage,
-                  WriteStorage};
+pub use storage::{
+    DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage, ReadStorage, Storage, Tracked,
+    VecStorage, WriteStorage, ComponentEvent,
+};
 pub use world::{Builder, Component, Entities, Entity, EntityBuilder, LazyUpdate, World};

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -62,8 +62,9 @@ use shrev::EventChannel;
 ///         self.inserted.clear();
 ///
 ///         // Here we can populate the bitsets by iterating over the events.
-///         // You can also just iterate over the events without using a bitset, but this
-///         // allows us to use them in joins with components.
+///         // You can also just iterate over the events without using a bitset which will
+///         // give you an ordered history of the events (which is good for caches and synchronizing
+///         // other storages, but this allows us to use them in joins with components.
 ///         {
 ///             let events = comps.channel()
 ///                 .read(&mut self.reader_id);
@@ -91,7 +92,9 @@ use shrev::EventChannel;
 ///             // ...
 ///         }
 ///
-///         // Instead do something like:
+///         // Instead you will want to restrict the amount of components iterated over, either through
+///         // other components in the join, or by using `RestrictedStorage` and only getting the component
+///         // mutably when you are sure you need to modify it.
 ///#        let condition = true;
 ///         for (entity, mut comps) in (&entities, &mut comps.restrict_mut()).join() {
 ///             if condition { // check whether this component should be modified.
@@ -123,7 +126,7 @@ use shrev::EventChannel;
 ///     // you start tracking them.
 ///     let mut comps = world.write_storage::<Comp>();
 ///     let comp_system = CompSystem {
-///         reader_id: comps.track(),
+///         reader_id: comps.register_reader(),
 ///         modified: BitSet::new(),
 ///         inserted: BitSet::new(),
 ///     };

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -66,8 +66,7 @@ use shrev::EventChannel;
 ///         // allows us to use them in joins with components.
 ///         {
 ///             let events = comps.channel()
-///                 .read(&mut self.reader_id)
-///                 .collect::<Vec<&ComponentEvent>>();
+///                 .read(&mut self.reader_id);
 ///             for event in events {
 ///                 match event {
 ///                     ComponentEvent::Modified(id) => { self.modified.add(*id); },

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,12 +3,14 @@
 pub use self::data::{ReadStorage, WriteStorage};
 pub use self::flagged::FlaggedStorage;
 pub use self::generic::{GenericReadStorage, GenericWriteStorage};
-pub use self::restrict::{ImmutableParallelRestriction, MutableParallelRestriction,
-                         RestrictedStorage, SequentialRestriction};
+pub use self::restrict::{
+    ImmutableParallelRestriction, MutableParallelRestriction, RestrictedStorage,
+    SequentialRestriction,
+};
 #[cfg(feature = "rudy")]
 pub use self::storages::RudyStorage;
 pub use self::storages::{BTreeStorage, DenseVecStorage, HashMapStorage, NullStorage, VecStorage};
-pub use self::track::{InsertedFlag, ModifiedFlag, RemovedFlag, TrackChannels, Tracked};
+pub use self::track::{ComponentEvent, Tracked};
 
 use std;
 use std::marker::PhantomData;
@@ -381,7 +383,8 @@ where
                 }))
             }
         } else {
-            let gen = self.entities
+            let gen = self
+                .entities
                 .alloc
                 .generation(e.id())
                 .unwrap_or(Generation::one());
@@ -442,11 +445,9 @@ where
     }
 }
 
-unsafe impl<'a, T: Component, D> DistinctStorage for Storage<'a, T, D>
-where
-    T::Storage: DistinctStorage,
-{
-}
+unsafe impl<'a, T: Component, D> DistinctStorage for Storage<'a, T, D> where
+    T::Storage: DistinctStorage
+{}
 
 impl<'a, 'e, T, D> Join for &'a Storage<'e, T, D>
 where
@@ -483,8 +484,7 @@ where
     T: Component,
     D: Deref<Target = MaskedStorage<T>>,
     T::Storage: Sync,
-{
-}
+{}
 
 impl<'a, 'e, T, D> Join for &'a mut Storage<'e, T, D>
 where
@@ -513,8 +513,7 @@ where
     T: Component,
     D: DerefMut<Target = MaskedStorage<T>>,
     T::Storage: Sync + DistinctStorage,
-{
-}
+{}
 
 /// Tries to create a default value, returns an `Err` with the name of the storage and/or component
 /// if there's no default.

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -759,7 +759,7 @@ mod test {
         let mut inserted = BitSet::new();
         let mut modified = BitSet::new();
         let mut removed = BitSet::new();
-        let mut reader_id = s1.track();
+        let mut reader_id = s1.register_reader();
 
         for i in 0..15 {
             let entity = w.entities().create();

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -757,13 +757,9 @@ mod test {
         let mut s1: Storage<FlaggedCvec, _> = w.write_storage();
 
         let mut inserted = BitSet::new();
-        let mut inserted_id = s1.track_inserted();
-
         let mut modified = BitSet::new();
-        let mut modified_id = s1.track_modified();
-
         let mut removed = BitSet::new();
-        let mut removed_id = s1.track_removed();
+        let mut reader_id = s1.track();
 
         for i in 0..15 {
             let entity = w.entities().create();
@@ -773,12 +769,19 @@ mod test {
         }
 
         {
+            let events = s1.channel().read(&mut reader_id).collect::<Vec<&ComponentEvent>>();
+
             inserted.clear();
-            s1.populate_inserted(&mut inserted_id, &mut inserted);
             modified.clear();
-            s1.populate_modified(&mut modified_id, &mut modified);
             removed.clear();
-            s1.populate_removed(&mut removed_id, &mut removed);
+
+            for event in events {
+                match event {
+                    ComponentEvent::Modified(id) => modified.add(*id),
+                    ComponentEvent::Inserted(id) => inserted.add(*id),
+                    ComponentEvent::Removed(id) => removed.add(*id),
+                };
+            }
         }
 
         for (entity, _) in (&w.entities(), &s1).join() {
@@ -791,13 +794,21 @@ mod test {
             comp.0 += 1;
         }
 
+
         {
+            let events = s1.channel().read(&mut reader_id).collect::<Vec<&ComponentEvent>>();
+
             inserted.clear();
-            s1.populate_inserted(&mut inserted_id, &mut inserted);
             modified.clear();
-            s1.populate_modified(&mut modified_id, &mut modified);
             removed.clear();
-            s1.populate_removed(&mut removed_id, &mut removed);
+
+            for event in events {
+                match event {
+                    ComponentEvent::Modified(id) => modified.add(*id),
+                    ComponentEvent::Inserted(id) => inserted.add(*id),
+                    ComponentEvent::Removed(id) => removed.add(*id),
+                };
+            }
         }
 
         for (entity, _) in (&w.entities(), &s1).join() {
@@ -811,12 +822,19 @@ mod test {
         }
 
         {
+            let events = s1.channel().read(&mut reader_id).collect::<Vec<&ComponentEvent>>();
+
             inserted.clear();
-            s1.populate_inserted(&mut inserted_id, &mut inserted);
             modified.clear();
-            s1.populate_modified(&mut modified_id, &mut modified);
             removed.clear();
-            s1.populate_removed(&mut removed_id, &mut removed);
+
+            for event in events {
+                match event {
+                    ComponentEvent::Modified(id) => modified.add(*id),
+                    ComponentEvent::Inserted(id) => inserted.add(*id),
+                    ComponentEvent::Removed(id) => removed.add(*id),
+                };
+            }
         }
 
         for (entity, _) in (&w.entities(), &s1).join() {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -769,12 +769,11 @@ mod test {
         }
 
         {
-            let events = s1.channel().read(&mut reader_id).collect::<Vec<&ComponentEvent>>();
-
             inserted.clear();
             modified.clear();
             removed.clear();
 
+            let events = s1.channel().read(&mut reader_id);
             for event in events {
                 match event {
                     ComponentEvent::Modified(id) => modified.add(*id),
@@ -796,12 +795,11 @@ mod test {
 
 
         {
-            let events = s1.channel().read(&mut reader_id).collect::<Vec<&ComponentEvent>>();
-
             inserted.clear();
             modified.clear();
             removed.clear();
 
+            let events = s1.channel().read(&mut reader_id);
             for event in events {
                 match event {
                     ComponentEvent::Modified(id) => modified.add(*id),
@@ -822,12 +820,11 @@ mod test {
         }
 
         {
-            let events = s1.channel().read(&mut reader_id).collect::<Vec<&ComponentEvent>>();
-
             inserted.clear();
             modified.clear();
             removed.clear();
 
+            let events = s1.channel().read(&mut reader_id);
             for event in events {
                 match event {
                     ComponentEvent::Modified(id) => modified.add(*id),

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -53,12 +53,14 @@ where
         unsafe { self.open() }.1.channel_mut()
     }
 
-    /// Starts tracking component events.
-    pub fn track(&mut self) -> ReaderId<ComponentEvent> {
+    /// Starts tracking component events. Note that this reader id should be used every frame,
+    /// otherwise events will pile up and memory use by the event channel will grow waiting
+    /// for this reader.
+    pub fn register_reader(&mut self) -> ReaderId<ComponentEvent> {
         self.channel_mut().register_reader()
     }
 
-    /// Flags an index.
+    /// Flags an index with a `ComponentEvent`.
     pub fn flag(&mut self, event: ComponentEvent) {
         self.channel_mut().single_write(event);
     }

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -1,4 +1,3 @@
-use std::iter::Extend;
 use std::ops::{Deref, DerefMut};
 
 use shrev::{EventChannel, ReaderId};
@@ -17,9 +16,16 @@ pub trait Tracked {
 }
 
 #[derive(Debug, Copy, Clone)]
+/// Component storage events received from a `FlaggedStorage` or any storage that implements
+/// `Tracked`.
 pub enum ComponentEvent {
+    /// An insertion event, note that a modification event will be triggered if the entity
+    /// already had a component and had a new one inserted.
     Inserted(Index),
+    /// A modification event, this will be sent any time a component is accessed mutably so be
+    /// careful with joins over `&mut storages` as it could potentially flag all of them.
     Modified(Index),
+    /// A removal event.
     Removed(Index),
 }
 

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -10,44 +10,16 @@ use world::{Component, Index};
 /// `UnprotectedStorage`s that track modifications, insertions, and
 /// removals of components.
 pub trait Tracked {
-    /// Event channels tracking modified/inserted/removed components.
-    fn channels(&self) -> &TrackChannels;
-    /// Mutable event channels tracking modified/inserted/removed components.
-    fn channels_mut(&mut self) -> &mut TrackChannels;
+    /// Event channel tracking modified/inserted/removed components.
+    fn channel(&self) -> &EventChannel<ComponentEvent>;
+    /// Mutable event channel tracking modified/inserted/removed components.
+    fn channel_mut(&mut self) -> &mut EventChannel<ComponentEvent>;
 }
 
-/// All three types of tracked modifications to components.
-pub struct TrackChannels {
-    /// Modifications event channel.
-    ///
-    /// Note: This does not include insertions, only when a component is changed
-    /// after it has been added to an entity.
-    pub modify: EventChannel<ModifiedFlag>,
-    /// Insertions event channel.
-    ///
-    /// Note: Insertion events only occur when something inserts a component without
-    /// there being a pre-existing component. If there is a pre-existing component
-    /// for an entity then it will fire a modification event.
-    pub insert: EventChannel<InsertedFlag>,
-    /// Removed event channel.
-    pub remove: EventChannel<RemovedFlag>,
-}
-
-impl TrackChannels {
-    /// Creates a new structure that holds all types of component modification events.
-    pub fn new() -> Self {
-        Default::default()
-    }
-}
-
-impl Default for TrackChannels {
-    fn default() -> Self {
-        TrackChannels {
-            modify: EventChannel::new(),
-            insert: EventChannel::new(),
-            remove: EventChannel::new(),
-        }
-    }
+pub enum ComponentEvent {
+    Inserted(Index),
+    Modified(Index),
+    Removed(Index),
 }
 
 impl<'e, T, D> Storage<'e, T, D>
@@ -57,47 +29,8 @@ where
     D: Deref<Target = MaskedStorage<T>>,
 {
     /// Returns the event channel tracking modified components.
-    pub fn channels(&self) -> &TrackChannels {
-        unsafe { self.open() }.1.channels()
-    }
-
-    /// Returns the event channel tracking modified components.
-    pub fn modified(&self) -> &EventChannel<ModifiedFlag> {
-        &self.channels().modify
-    }
-
-    /// Returns the event channel tracking inserted components.
-    pub fn inserted(&self) -> &EventChannel<InsertedFlag> {
-        &self.channels().insert
-    }
-
-    /// Returns the event channel tracking removed components.
-    pub fn removed(&self) -> &EventChannel<RemovedFlag> {
-        &self.channels().remove
-    }
-
-    /// Reads events from the modified `EventChannel` and populates a structure using the events.
-    pub fn populate_modified<E>(&self, reader_id: &mut ReaderId<ModifiedFlag>, value: &mut E)
-    where
-        E: Extend<Index>,
-    {
-        value.extend(self.modified().read(reader_id).map(|flag| *flag.as_ref()));
-    }
-
-    /// Reads events from the inserted `EventChannel` and populates a structure using the events.
-    pub fn populate_inserted<E>(&self, reader_id: &mut ReaderId<InsertedFlag>, value: &mut E)
-    where
-        E: Extend<Index>,
-    {
-        value.extend(self.inserted().read(reader_id).map(|flag| *flag.as_ref()));
-    }
-
-    /// Reads events from the removed `EventChannel` and populates a structure using the events.
-    pub fn populate_removed<E>(&self, reader_id: &mut ReaderId<RemovedFlag>, value: &mut E)
-    where
-        E: Extend<Index>,
-    {
-        value.extend(self.removed().read(reader_id).map(|flag| *flag.as_ref()));
+    pub fn channel(&self) -> &EventChannel<ComponentEvent> {
+        unsafe { self.open() }.1.channel()
     }
 }
 
@@ -107,85 +40,20 @@ where
     T::Storage: Tracked,
     D: DerefMut<Target = MaskedStorage<T>>,
 {
-    /// Returns all of the event channels for this component.
-    pub fn channels_mut(&mut self) -> &mut TrackChannels {
-        unsafe { self.open() }.1.channels_mut()
+    /// Returns the event channel for insertions/removals/modifications of this storage's
+    /// components.
+    pub fn channel_mut(&mut self) -> &mut EventChannel<ComponentEvent> {
+        unsafe { self.open() }.1.channel_mut()
     }
 
-    /// Returns the event channel tracking modified components mutably.
-    pub fn modified_mut(&mut self) -> &mut EventChannel<ModifiedFlag> {
-        &mut self.channels_mut().modify
+    /// Starts tracking component events.
+    pub fn track(&mut self) -> ReaderId<ComponentEvent> {
+        self.channel_mut().register_reader()
     }
 
-    /// Returns the event channel tracking inserted components mutably.
-    pub fn inserted_mut(&mut self) -> &mut EventChannel<InsertedFlag> {
-        &mut self.channels_mut().insert
-    }
-
-    /// Returns the event channel tracking removed components mutably.
-    pub fn removed_mut(&mut self) -> &mut EventChannel<RemovedFlag> {
-        &mut self.channels_mut().remove
-    }
-
-    /// Starts tracking modified events.
-    pub fn track_modified(&mut self) -> ReaderId<ModifiedFlag> {
-        self.modified_mut().register_reader()
-    }
-
-    /// Starts tracking inserted events.
-    pub fn track_inserted(&mut self) -> ReaderId<InsertedFlag> {
-        self.inserted_mut().register_reader()
-    }
-
-    /// Starts tracking removed events.
-    pub fn track_removed(&mut self) -> ReaderId<RemovedFlag> {
-        self.removed_mut().register_reader()
-    }
-
-    /// Flags an index as modified.
-    pub fn flag_modified(&mut self, id: Index) {
-        self.modified_mut().single_write(id.into());
-    }
-
-    /// Flags an index as inserted.
-    pub fn flag_inserted(&mut self, id: Index) {
-        self.inserted_mut().single_write(id.into());
-    }
-
-    /// Flags an index as removed.
-    pub fn flag_removed(&mut self, id: Index) {
-        self.removed_mut().single_write(id.into());
+    /// Flags an index.
+    pub fn flag(&mut self, event: ComponentEvent) {
+        self.channel_mut().single_write(event);
     }
 }
 
-macro_rules! flag {
-    ( $( $name:ident ),* ) => {
-        $(
-            /// Flag with additional type safety against which kind of
-            /// operations were done.
-            #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-            pub struct $name(Index);
-            impl Deref for $name {
-                type Target = Index;
-                fn deref(&self) -> &Self::Target {
-                    &self.0
-                }
-            }
-
-            impl AsRef<Index> for $name {
-                fn as_ref(&self) -> &Index {
-                    &self.0
-                }
-            }
-
-            impl From<Index> for $name {
-                fn from(flag: Index) -> Self {
-                    $name(flag)
-                }
-            }
-        )*
-    }
-}
-
-// Separate types for type safety reasons.
-flag!(ModifiedFlag, InsertedFlag, RemovedFlag);

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -16,6 +16,7 @@ pub trait Tracked {
     fn channel_mut(&mut self) -> &mut EventChannel<ComponentEvent>;
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum ComponentEvent {
     Inserted(Index),
     Modified(Index),


### PR DESCRIPTION
Related issue: https://github.com/amethyst/amethyst/issues/978

Uses a `ComponentEvent` enum instead of 3 separate channels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/489)
<!-- Reviewable:end -->
