### PR TITLE
Allow accessing fetched entities of a `Storage`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs"
-version = "0.14.0"
+version = "0.14.1"
 description = """
 Specs is an Entity-Component System library written in Rust.
 """

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -202,6 +202,14 @@ where
         &self.data.inner
     }
 
+    /// Returns the `EntitesRes` resource fetched by this storage.
+    /// **This does not have anything to do with the components inside.**
+    /// You only want to use this when implementing additional methods
+    /// for `Storage` via an extension trait.
+    pub fn fetched_entities(&self) -> &EntitiesRes {
+        &self.entities
+    }
+
     /// Tries to read the data associated with an `Entity`.
     pub fn get(&self, e: Entity) -> Option<&T> {
         if self.data.mask.contains(e.id()) && self.entities.is_alive(e) {


### PR DESCRIPTION
I've added `Storage::entities` to allow making extension methods for `Storage` that return `Entity`.

This method is hidden because I'm 100% certain newcomers will be confused by this otherwise. This makes it less visible, yes, but I think that's worth for avoiding this confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/515)
<!-- Reviewable:end -->
