### PR TITLE
[DO NOT MERGE] Updating resources

### DIFF
--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -440,6 +440,13 @@ impl World {
         }
     }
 
+    /// Adds a resource to the world, if the resource does not exist yet. See `add_resource` for more information.
+    pub fn add_resource_soft<T: Resource>(&mut self, res: T) {
+        if !self.res.has_value::<T>() {
+            self.add_resource(res);
+        }
+    }
+
     /// Fetches a component's storage for reading.
     ///
     /// ## Panics
@@ -482,6 +489,13 @@ impl World {
     /// Panics if the resource has not been added.
     pub fn write_resource<T: Resource>(&self) -> FetchMut<T> {
         self.res.fetch_mut()
+    }
+
+    /// Updates a resource if the resource is None. 
+    pub fn update_resource_if_none<T: Resource>(&mut self, res: Option<T>) {
+        if (self.read_resource::<Option<T>>()).is_none() {
+            *self.write_resource() = res
+        }
     }
 
     /// Convenience method for fetching entities.


### PR DESCRIPTION
There is currently no API (at least in `World`) for checking if a resource already exists. Fetching may result in a panic, which is bad or a `Default`, which adds boilerplate, because we need to check against the default what would look like this: 
```rust
// we assume the Resource has a Default, so we won't panic
if world.read_resource::<Res>() == Res::default() {
    *world.write_resource() = Res::init();// <- costly initialization like loading from disk or calculate something heavy like 3+4 ^.^
}
```
Using `world.add_resource(Resd::init())` overrides the actual resource if existing, which is bad for obvious reasons.
This makes updating resources less clear, especially in [`State>>on_start`](https://www.amethyst.rs/doc/latest/doc/amethyst/trait.State.html#method.on_start).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/522)
<!-- Reviewable:end -->
