### PR TITLE
Fix `FlaggedStorage` docs

### DIFF
--- a/book/src/12_tracked.md
+++ b/book/src/12_tracked.md
@@ -51,7 +51,11 @@ impl<'a> System<'a> for Sys {
                 ComponentEvent::Modified(id) | ComponentEvent::Inserted(id) => {
                     self.dirty.add(*id);
                 }
-                ComponentEvent::Removed(_) => (),
+                 // We don't need to take this event into account since
+                 // removed components will be filtered out by the join;
+                 // if you want to, you can use `self.dirty.remove(*id);`
+                 // so the bit set only contains IDs that still exist
+                 ComponentEvent::Removed(_) => (),
             }
         }
 


### PR DESCRIPTION
The documentation for `FlaggedStorage` became out of date with #489. I'm not entirely familiar with this API, so please review to see if my understanding of the changes is correct. I have however made sure that the code sample compiles.

The bit about handling `ComponentEvent::Removed` first is no longer necessary because the events are in the same "channel" and in chronological order, right?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/531)
<!-- Reviewable:end -->
