### PR TITLE
documentation: fix link to World struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! `World` is where component storages, resources and entities are stored.
 //! See the docs of [`World`] for more.
 //!
-//! [`World`]: struct.World.html
+//! [`World`]: world/struct.World.html
 //!
 //! [`Component`]s can be easily implemented like this:
 //!


### PR DESCRIPTION
broken link in https://docs.rs/specs/0.14.3/specs/#the-data: https://docs.rs/specs/0.14.3/specs/struct.World.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/556)
<!-- Reviewable:end -->
