### PR TITLE
Fix typo in 09_parallel_join.md

### DIFF
--- a/book/src/09_parallel_join.md
+++ b/book/src/09_parallel_join.md
@@ -7,7 +7,7 @@ to the same resource where at least one of them needs write access to it).
 
 [c3]: ./03_dispatcher.html
 
-## Basic parallization
+## Basic parallelization
 
 What isn't automatically parallelized by Specs are
 the joins made within a single system:


### PR DESCRIPTION
I was reading online, and spotted a minor typo - the 'el' was omitted in 'parallelization'. Add it back.

<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

<!-- Please make it clear if your change is breaking. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/560)
<!-- Reviewable:end -->
