### PR TITLE
fix: book example variable mutability

### DIFF
--- a/book/src/06_system_data.md
+++ b/book/src/06_system_data.md
@@ -63,7 +63,7 @@ impl<'a> System<'a> for StoneCreator {
         Read<'a, LazyUpdate>,
     );
 
-    fn run(&mut self, (entities, stones, updater): Self::SystemData) {
+    fn run(&mut self, (entities, mut stones, updater): Self::SystemData) {
         let stone = entities.create();
 
         // 1) Either we insert the component by writing to its storage


### PR DESCRIPTION
## Checklist

* [x] I've updated the book to reflect my changes

I'm currently going through the book and noticed a complaint by the compiler here when using `stones.insert(stone, Stone);`, stones should be marked as mutable, or am I missing something?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/577)
<!-- Reviewable:end -->
