### PR TITLE
Replace U64Marker with SimpleMarker<T: ?Sized>

### DIFF
--- a/examples/saveload.rs
+++ b/examples/saveload.rs
@@ -99,7 +99,6 @@ impl From<NoError> for Combined {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct NetworkSync;
 
 fn main() {

--- a/examples/saveload.rs
+++ b/examples/saveload.rs
@@ -22,7 +22,7 @@ use specs::{
 const ENTITIES: &str = "
 [
     (
-        marker: (0, PhantomData),
+        marker: (0),
         components: (
             Some((
                 x: 10,
@@ -32,7 +32,7 @@ const ENTITIES: &str = "
         ),
     ),
     (
-        marker: (1, PhantomData),
+        marker: (1),
         components: (
             Some(Pos(
                 x: 5,

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -366,7 +366,8 @@ pub trait MarkerAllocator<M: Marker>: Resource {
 /// Basic marker implementation usable for saving and loading, uses `u64` as identifier
 #[derive(Derivative, Serialize, Deserialize)]
 #[derivative(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct SimpleMarker<T: ?Sized>(u64, PhantomData<T>);
+#[repr(transparent)]
+pub struct SimpleMarker<T: ?Sized>(u64, #[serde(skip)] PhantomData<T>);
 
 impl<T> Component for SimpleMarker<T>
 where

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -40,7 +40,7 @@ mod uuid;
 pub use self::uuid::{UuidMarker, UuidMarkerAllocator};
 pub use self::{
     de::DeserializeComponents,
-    marker::{MarkedBuilder, Marker, MarkerAllocator, U64Marker, U64MarkerAllocator},
+    marker::{MarkedBuilder, Marker, MarkerAllocator, SimpleMarker, SimpleMarkerAllocator},
     ser::SerializeComponents,
 };
 

--- a/src/saveload/tests.rs
+++ b/src/saveload/tests.rs
@@ -25,12 +25,15 @@ mod marker_test {
         type Storage = VecStorage<Self>;
     }
 
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct NetworkSync;
+
     /// Ensure that the marker correctly allocates IDs for entities that come
     /// from mixed sources: normal entity creation, lazy creation, and
     /// deserialization.
     #[test]
     fn bumps_index_after_reload() {
-        bumps_index_after_reload_internal::<U64Marker>(U64MarkerAllocator::new());
+        bumps_index_after_reload_internal::<SimpleMarker<NetworkSync>>(SimpleMarkerAllocator::new());
         #[cfg(feature = "uuid_entity")]
         bumps_index_after_reload_internal::<UuidMarker>(UuidMarkerAllocator::new());
     }
@@ -156,7 +159,7 @@ mod marker_test {
         assert_markers_are_unique::<M>(&mut world);
     }
 
-    /// Assert that the number of entities marked with `U64Marker` is equal to
+    /// Assert that the number of entities marked with `SimpleMarker` is equal to
     /// `count`
     fn assert_marked_entity_count<M: Marker>(world: &mut World, count: usize) {
         world.exec(|(ents, markers): (Entities, ReadStorage<M>)| {

--- a/src/saveload/tests.rs
+++ b/src/saveload/tests.rs
@@ -25,7 +25,6 @@ mod marker_test {
         type Storage = VecStorage<Self>;
     }
 
-    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
     struct NetworkSync;
 
     /// Ensure that the marker correctly allocates IDs for entities that come

--- a/tests/saveload.rs
+++ b/tests/saveload.rs
@@ -13,7 +13,7 @@ extern crate specs_derive;
 mod tests {
     use spocs::{
         error::NoError,
-        saveload::{ConvertSaveload, Marker, U64Marker},
+        saveload::{ConvertSaveload, Marker, SimpleMarker},
         Builder, Entity, World, WorldExt,
     };
     #[cfg(feature = "uuid_entity")]
@@ -60,11 +60,14 @@ mod tests {
 
     impl EntityLike for Entity {}
 
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct NetworkSync;
+
     #[test]
     fn type_check() {
         let mut world = World::new();
         let entity = world.create_entity().build();
-        type_check_internal::<U64Marker>(entity);
+        type_check_internal::<SimpleMarker<NetworkSync>>(entity);
         #[cfg(feature = "uuid_entity")]
         type_check_internal::<UuidMarker>(entity);
     }

--- a/tests/saveload.rs
+++ b/tests/saveload.rs
@@ -60,7 +60,6 @@ mod tests {
 
     impl EntityLike for Entity {}
 
-    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
     struct NetworkSync;
 
     #[test]


### PR DESCRIPTION
Fixes #592 

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [x] I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* [x] Usage of new public items is shown in the API docs

## API changes

Breaking change: 

`specs::saveload::U64Marker` is replaced with `SimpleMarker<T>`
`specs::saveload::U64MarkerAllocator` is replaced with `SimpleMarkerAllocator<T>`
This change allows multiple instances of SimpleMarker(Allocator) to be used in a single World

`SimpleMarker` is no longer `PartialOrd + Ord` because `derivative` doesn't implement those traits, however they are trivial to implement, up to you to decide whether I should

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/specs/594)
<!-- Reviewable:end -->
