### PR TITLE
Changes AntiStorage inner to public

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -45,7 +45,7 @@ mod track;
 
 /// An inverted storage type, only useful to iterate entities
 /// that do not have a particular component type.
-pub struct AntiStorage<'a>(&'a BitSet);
+pub struct AntiStorage<'a>(pub &'a BitSet);
 
 impl<'a> Join for AntiStorage<'a> {
     type Mask = BitSetNot<&'a BitSet>;


### PR DESCRIPTION
The AntiStorage inner being private prevented any external users of specs to implement an AntiStorage type, which the blanket std::ops::Not implementation requires for allowing negative joins (!&storage). 

This changes the AntiStorage inner to public, allowing external crates to now implement this appropriately

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

AntiStorage inner is now public
