### PR TITLE
Make FlaggedStorage Parallel compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* `FlaggedStorage` is now parallel join compatible. Added `AnyStorage::maintain`, `MaskedStorage::mantain` and
+`FlaggedStorage::maintain`. ([#PR])
+
 # 0.14.2
 
 * Add `Join`-able entries API to `Storage` ([#518])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 * `FlaggedStorage` is now parallel join compatible. Added `AnyStorage::maintain`, `MaskedStorage::mantain` and
-`FlaggedStorage::maintain`. ([#PR])
+`FlaggedStorage::maintain`. ([#609])
+
+[#609]: https://github.com/slide-rs/specs/pull/609
 
 # 0.14.2
 


### PR DESCRIPTION
This PR adds a chain of 'maintain' functions which can be used for internally maintaining storages. This propagates up up from `AnyStorage -> MaskedStorage -> FlaggedStorage`, which means now all storages have thet ability (but a default impl exists) to internally maintain their state. This maintain is called by `World::maintain`, which has a reasonable expectation to be called in a thread safe manner once a frame (LazyUpdate garuntee). 

Because of this, now FlaggedStorage supports parallel iteration. This is accomplished by queuing all FlaggedStorage updates internally to the storage. These events are then not actually fired until the end of the frame during `World::maintain`. I believe this is  a reasonable and understood cost of allowing parallel joins for FlaggedStorage. 

This should open up a huge optimization in amethyst as well, as we can now par_join global_matrix updates.

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [x] Usage of new public items is shown in the API docs

## API changes

* Adds `AnyStorage::maintain` method, which is also a default implementation.
* Adds `MaskedStorage::maintain` method, which calls the `self.inner.maintain()` implementation
* Adds `FlaggedStorage::maintain` method
