### PR TITLE
Start and Stop signal registration for the FlaggedStorage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,12 @@ nightly = ["shred/nightly"]
 uuid_entity = ["uuid", "serde"]
 stdweb = ["uuid/stdweb"]
 wasm-bindgen = ["uuid/wasm-bindgen"]
+storage-event-control = []
 
 shred-derive = ["shred/shred-derive"]
 
 [package.metadata.docs.rs]
-features = ["parallel", "serde", "shred-derive", "specs-derive", "nightly", "uuid_entity"]
+features = ["parallel", "serde", "shred-derive", "specs-derive", "nightly", "uuid_entity", "storage-event-control"]
 
 [dev-dependencies]
 cgmath =  { version = "0.17" }

--- a/docs/tutorials/src/12_tracked.md
+++ b/docs/tutorials/src/12_tracked.md
@@ -83,3 +83,12 @@ There are three different event types that we can receive:
 Note that because of how `ComponentEvent` works, if you iterate mutably over a
 component storage using `Join`, all entities that are fetched by the `Join` will
 be flagged as modified even if nothing was updated in them.
+
+## Start and Stop event emission
+
+Sometimes you may want to perform some operations on the storage, but you don't want
+that these operations produce any event.
+
+You can use the function `storage.set_event_emission(false)` to suppress the event writing for
+of any action. When you want to re activate them you can simply call
+`storage.set_event_emission(true)`.

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -19,9 +19,11 @@ pub trait Tracked {
     /// Controls the events signal emission.
     /// When this is set to false the events modified/inserted/removed are
     /// not emitted.
+    #[cfg(feature = "storage-event-control")]
     fn set_event_emission(&mut self, emit: bool);
 
     /// Returns the actual state of the event emission.
+    #[cfg(feature = "storage-event-control")]
     fn event_emission(&self) -> bool;
 }
 
@@ -52,6 +54,7 @@ where
     }
 
     /// Returns the actual state of the event emission.
+    #[cfg(feature = "storage-event-control")]
     pub fn event_emission(&self) -> bool {
         unsafe { self.open() }.1.event_emission()
     }
@@ -84,6 +87,7 @@ where
     /// Controls the events signal emission.
     /// When this is set to false the events modified/inserted/removed are
     /// not emitted.
+    #[cfg(feature = "storage-event-control")]
     pub fn set_event_emission(&mut self, emit: bool) {
         unsafe { self.open() }.1.set_event_emission(emit);
     }

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -15,6 +15,14 @@ pub trait Tracked {
     fn channel(&self) -> &EventChannel<ComponentEvent>;
     /// Mutable event channel tracking modified/inserted/removed components.
     fn channel_mut(&mut self) -> &mut EventChannel<ComponentEvent>;
+
+    /// Controls the events signal emission.
+    /// When this is set to false the events modified/inserted/removed are
+    /// not emitted.
+    fn set_event_emission(&mut self, emit: bool);
+
+    /// Returns the actual state of the event emission.
+    fn event_emission(&self) -> bool;
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -42,6 +50,11 @@ where
     pub fn channel(&self) -> &EventChannel<ComponentEvent> {
         unsafe { self.open() }.1.channel()
     }
+
+    /// Returns the actual state of the event emission.
+    pub fn event_emission(&self) -> bool {
+        unsafe { self.open() }.1.event_emission()
+    }
 }
 
 impl<'e, T, D> Storage<'e, T, D>
@@ -66,5 +79,12 @@ where
     /// Flags an index with a `ComponentEvent`.
     pub fn flag(&mut self, event: ComponentEvent) {
         self.channel_mut().single_write(event);
+    }
+
+    /// Controls the events signal emission.
+    /// When this is set to false the events modified/inserted/removed are
+    /// not emitted.
+    pub fn set_event_emission(&mut self, emit: bool) {
+        unsafe { self.open() }.1.set_event_emission(emit);
     }
 }


### PR DESCRIPTION
Sometimes you may want to perform some operations on the storage, but you don't want
that these operations produce any event.

You can use the function `storage.set_event_emission(false)` to suppress the event writing for
of any action. When you want to re activate them you can simply call
`storage.set_event_emission(true)`

This change will be used to fix this: https://github.com/amethyst/amethyst/issues/1795

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [x] I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* [x] Usage of new public items is shown in the API docs
