### PR TITLE
Remove dependency on nonzero_signed crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ mopa = "0.2"
 shred = { version = "0.9.1", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.3"
-nonzero_signed = "1.0.1"
 
 rayon = { version = "1.1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }


### PR DESCRIPTION
As of Rust 1.34, `std::num::NonZeroI32` is available to replace `nonzero_signed::NonZeroI32`. The nonzero_signed crate includes a deprecation warning to that effect, and `src/world/entity.rs` was already updated to the `std::num` type in #575 (specifically [here](https://github.com/slide-rs/specs/commit/0598748b48c56cdf859046dd878c8f2b1dc1e015#diff-ba4b568c0782727603e23606a69c685f)).

`specs` literally does not reference `nonzero_signed`, so there's nothing to do but remove it from `Cargo.toml`.

## Checklist

n/a. This PR does not affect the implementation in any way.

## API changes

n/a. This PR does not affect the API in any way.
