### PR TITLE
Make mopa optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 * Benchmark uses `nalgebra` instead of `cgmath`. ([#619]).
 * Bumped `shrev` from `1.0` to `1.1`. ([#619]).
+* Added a `mopa` feature and made the `mopa` dependency optional. ([#630])
 
 [#619]: https://github.com/slide-rs/specs/pull/619
+[#630]: https://github.com/slide-rs/specs/pull/630
 
 # 0.15.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ derivative = "1"
 hashbrown = "0.5.0"
 hibitset = { version = "0.6.1", default-features = false }
 log = "0.4"
-mopa = "0.2"
 shred = { version = "0.9.1", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.3"
 nonzero_signed = "1.0.1"
 
+mopa = { version = "0.2", optional = true }
 rayon = { version = "1.1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 specs-derive = { version = "0.4.0", path = "specs-derive", optional = true }
@@ -49,7 +49,7 @@ wasm-bindgen = ["uuid/wasm-bindgen"]
 shred-derive = ["shred/shred-derive"]
 
 [package.metadata.docs.rs]
-features = ["parallel", "serde", "shred-derive", "specs-derive", "nightly", "uuid_entity"]
+features = ["parallel", "serde", "shred-derive", "specs-derive", "nightly", "uuid_entity", "mopa"]
 
 [dev-dependencies]
 nalgebra = "0.18"

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,4 +1,7 @@
+#[cfg(feature="mopa")]
 use mopa::Any;
+#[cfg(not(feature="mopa"))]
+use std::any::Any;
 
 use super::*;
 use crate::world::{Component, Entity, Generation, Index, WorldExt};

--- a/src/world/comp.rs
+++ b/src/world/comp.rs
@@ -1,4 +1,7 @@
+#[cfg(feature="mopa")]
 use mopa::Any;
+#[cfg(not(feature="mopa"))]
+use std::any::Any;
 
 use crate::storage::UnprotectedStorage;
 


### PR DESCRIPTION
`std::any::Any` ought to be suitable for most users. If someone knows they want `Component` to require `mopa::Any`, they should opt-in via a feature flag.

[`mopa::Any`](https://docs.rs/mopa/0.2.2/mopa/trait.Any.html) describes itself as:

> This is a simple wrapper around `std::any::Any` which exists for technical reasons. Every type that implements `std::any::Any` implements this `Any`.

[`std::any::Any`](https://doc.rust-lang.org/std/any/trait.Any.html) gained `downcast_ref()` and `type_id()` in the years since `mopa` was released. `mopa::Any` also doesn't perform any function inside `specs`, so unless a user asks for `specs::Component` to have that dependency, I think it's reasonable to use `std::any::Any` instead.

## Checklist

* **n/a** I've added tests for all code changes and additions (where applicable)
* **n/a** I've added a demonstration of the new feature to one or more examples
* **n/a** I've updated the book to reflect my changes
* **n/a** Usage of new public items is shown in the API docs

Nothing in the `specs` repo except the `Component` definition and an associated generic type in a test refer to `Any`, and even then only in type bounds. No tests or examples are affected.

## API changes

This change breaks any code which specifically needs `trait Component: mopa::Any` by requiring them to use the new `mopa` feature:

```toml
specs = { version = "*", features = ["mopa" ] }
```

I added a changelog entry to that effect.