### PR TITLE
Remove dependency on mopa crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ derivative = "1"
 hashbrown = "0.5.0"
 hibitset = { version = "0.6.1", default-features = false }
 log = "0.4"
-mopa = "0.2"
 shred = { version = "0.9.1", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.3"

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,4 +1,4 @@
-use mopa::Any;
+use std::any::Any;
 
 use super::*;
 use crate::world::{Component, Entity, Generation, Index, WorldExt};

--- a/src/world/comp.rs
+++ b/src/world/comp.rs
@@ -1,4 +1,4 @@
-use mopa::Any;
+use std::any::Any;
 
 use crate::storage::UnprotectedStorage;
 


### PR DESCRIPTION
`mopa::Any` is less necessary with changes to `std::any::Any`, and `specs` wasn't calling the `mopafy!()` macro for `Component` anyway.

## Checklist

* **n/a** I've added tests for all code changes and additions (where applicable)
* **n/a** I've added a demonstration of the new feature to one or more examples
* **n/a** I've updated the book to reflect my changes
* **n/a** Usage of new public items is shown in the API docs

Nothing in the `specs` repo except the `Component` definition and an associated generic type in a test refer to `Any`, and even then only in type bounds. No tests or examples are affected.

## API changes

This change breaks any code which specifically needs `trait Component: mopa::Any`, but as far as I can tell [that doesn't work now and hasn't since ±ever](https://github.com/slide-rs/specs/pull/630#issuecomment-524591868) since `specs` doesn't call the `mopafy!()` macro.