### PR TITLE
Updated Shred 9.3 and exposed Batch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ derivative = "1"
 hashbrown = "0.6.0"
 hibitset = { version = "0.6.1", default-features = false }
 log = "0.4"
-shred = { version = "0.9.1", default-features = false }
+shred = { version = "0.9.3", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.3"
 
@@ -56,7 +56,7 @@ criterion = "0.3"
 ron = "0.5"
 rand = "0.7"
 serde_json = "1.0"
-shred = { version = "0.9.0", features = ["shred-derive"] }
+shred = { version = "0.9.3", features = ["shred-derive"] }
 specs-derive = { path = "specs-derive", version = "0.4.0" }
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,8 +207,9 @@ pub mod world;
 
 pub use hibitset::BitSet;
 pub use shred::{
-    Accessor, Dispatcher, DispatcherBuilder, Read, ReadExpect, RunNow, StaticAccessor, System,
-    SystemData, World, Write, WriteExpect,
+    Accessor, AccessorCow, BatchAccessor, BatchController, BatchUncheckedWorld,
+    DefaultBatchControllerSystem, Dispatcher, DispatcherBuilder, Read, ReadExpect, RunNow,
+    RunningTime, StaticAccessor, System, SystemData, World, Write, WriteExpect,
 };
 pub use shrev::ReaderId;
 


### PR DESCRIPTION
Updated shred to the last 9.3 version and exposed new `Batch` structures + all other structures needed to create a `Batch` `System`.