### PR TITLE
update syn, quote and proc-macro2 to 1.0

### DIFF
--- a/specs-derive/Cargo.toml
+++ b/specs-derive/Cargo.toml
@@ -10,9 +10,9 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-proc-macro2 = "0.4"
-syn = "0.15"
-quote = "0.6"
+proc-macro2 = "1.0"
+syn = "1.0"
+quote = "1.0"
 
 [lib]
 proc-macro = true

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -321,7 +321,7 @@ fn saveload_enum(data: &DataEnum, name: &Ident, generics: &Generics) -> Saveload
         }
     }
 
-    let variants = &saveload.variants;
+    let variants = saveload.variants.iter();
 
     let (_, saveload_ty_generics, saveload_where_clause) = saveload_generics.split_for_impl();
     let enum_def = quote! {
@@ -333,7 +333,7 @@ fn saveload_enum(data: &DataEnum, name: &Ident, generics: &Generics) -> Saveload
     let mut big_match_ser = quote! {};
     let mut big_match_de = quote! {};
 
-    for variant in variants {
+    for variant in saveload.variants.iter() {
         let ident = &variant.ident;
 
         match &variant.fields {
@@ -467,5 +467,6 @@ fn replace_entity_type(ty: &mut Type) {
         Type::Infer(_) => unreachable!(),
         Type::Macro(_) => unreachable!(),
         Type::Verbatim(_) => unimplemented!(),
+        _ => unimplemented!(),
     }
 }

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -62,7 +62,7 @@ fn impl_component(ast: &DeriveInput) -> proc_macro2::TokenStream {
         .iter()
         .find(|attr| attr.path.segments[0].ident == "storage")
         .map(|attr| {
-            syn::parse2::<StorageAttribute>(attr.tts.clone())
+            syn::parse2::<StorageAttribute>(attr.tokens.clone())
                 .unwrap()
                 .storage
         })


### PR DESCRIPTION
Related #624, #625, #626

Just a simple version bump and small fixes of the changed item and field names.

## Checklist

* [ ] ~I've added tests for all code changes and additions (where applicable)~
* [ ] ~I've added a demonstration of the new feature to one or more examples~
* [ ] ~I've updated the book to reflect my changes~
* [ ] ~Usage of new public items is shown in the API docs~

The `Type` enum has been marked as `__Nonexhaustive` which is the reason for the default match arm addition in https://github.com/Veykril/specs/blob/e114bc59f09dcfb0b1fa16dbcd50e23bec431fd1/specs-derive/src/impl_saveload.rs#L470.
